### PR TITLE
feat(tailscale): access cluster on non-home network

### DIFF
--- a/kubernetes/tailscale/operator.yaml
+++ b/kubernetes/tailscale/operator.yaml
@@ -1,0 +1,4582 @@
+# Copyright (c) Tailscale Inc & AUTHORS
+# SPDX-License-Identifier: BSD-3-Clause
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: operator-oauth
+  namespace: tailscale
+stringData:
+  client_id: "<CLIENT_ID>"
+  client_secret: "<CLIENT_SECRET>"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: operator
+    namespace: tailscale
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: proxies
+    namespace: tailscale
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
+    name: connectors.tailscale.com
+spec:
+    group: tailscale.com
+    names:
+        kind: Connector
+        listKind: ConnectorList
+        plural: connectors
+        shortNames:
+            - cn
+        singular: connector
+    scope: Cluster
+    versions:
+        - additionalPrinterColumns:
+            - description: CIDR ranges exposed to tailnet by a subnet router defined via this Connector instance.
+              jsonPath: .status.subnetRoutes
+              name: SubnetRoutes
+              type: string
+            - description: Whether this Connector instance defines an exit node.
+              jsonPath: .status.isExitNode
+              name: IsExitNode
+              type: string
+            - description: Status of the deployed Connector resources.
+              jsonPath: .status.conditions[?(@.type == "ConnectorReady")].reason
+              name: Status
+              type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: |-
+                    Connector defines a Tailscale node that will be deployed in the cluster. The
+                    node can be configured to act as a Tailscale subnet router and/or a Tailscale
+                    exit node.
+                    Connector is a cluster-scoped resource.
+                    More info:
+                    https://tailscale.com/kb/1441/kubernetes-operator-connector
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: |-
+                            ConnectorSpec describes the desired Tailscale component.
+                            More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                            exitNode:
+                                description: |-
+                                    ExitNode defines whether the Connector node should act as a
+                                    Tailscale exit node. Defaults to false.
+                                    https://tailscale.com/kb/1103/exit-nodes
+                                type: boolean
+                            hostname:
+                                description: |-
+                                    Hostname is the tailnet hostname that should be assigned to the
+                                    Connector node. If unset, hostname defaults to <connector
+                                    name>-connector. Hostname can contain lower case letters, numbers and
+                                    dashes, it must not start or end with a dash and must be between 2
+                                    and 63 characters long.
+                                pattern: ^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$
+                                type: string
+                            proxyClass:
+                                description: |-
+                                    ProxyClass is the name of the ProxyClass custom resource that
+                                    contains configuration options that should be applied to the
+                                    resources created for this Connector. If unset, the operator will
+                                    create resources with the default configuration.
+                                type: string
+                            subnetRouter:
+                                description: |-
+                                    SubnetRouter defines subnet routes that the Connector node should
+                                    expose to tailnet. If unset, none are exposed.
+                                    https://tailscale.com/kb/1019/subnets/
+                                properties:
+                                    advertiseRoutes:
+                                        description: |-
+                                            AdvertiseRoutes refer to CIDRs that the subnet router should make
+                                            available. Route values must be strings that represent a valid IPv4
+                                            or IPv6 CIDR range. Values can be Tailscale 4via6 subnet routes.
+                                            https://tailscale.com/kb/1201/4via6-subnets/
+                                        items:
+                                            format: cidr
+                                            type: string
+                                        minItems: 1
+                                        type: array
+                                required:
+                                    - advertiseRoutes
+                                type: object
+                            tags:
+                                description: |-
+                                    Tags that the Tailscale node will be tagged with.
+                                    Defaults to [tag:k8s].
+                                    To autoapprove the subnet routes or exit node defined by a Connector,
+                                    you can configure Tailscale ACLs to give these tags the necessary
+                                    permissions.
+                                    See https://tailscale.com/kb/1337/acl-syntax#autoapprovers.
+                                    If you specify custom tags here, you must also make the operator an owner of these tags.
+                                    See  https://tailscale.com/kb/1236/kubernetes-operator/#setting-up-the-kubernetes-operator.
+                                    Tags cannot be changed once a Connector node has been created.
+                                    Tag values must be in form ^tag:[a-zA-Z][a-zA-Z0-9-]*$.
+                                items:
+                                    pattern: ^tag:[a-zA-Z][a-zA-Z0-9-]*$
+                                    type: string
+                                type: array
+                        type: object
+                        x-kubernetes-validations:
+                            - message: A Connector needs to be either an exit node or a subnet router, or both.
+                              rule: has(self.subnetRouter) || self.exitNode == true
+                    status:
+                        description: |-
+                            ConnectorStatus describes the status of the Connector. This is set
+                            and managed by the Tailscale operator.
+                        properties:
+                            conditions:
+                                description: |-
+                                    List of status conditions to indicate the status of the Connector.
+                                    Known condition types are `ConnectorReady`.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - type
+                                x-kubernetes-list-type: map
+                            hostname:
+                                description: |-
+                                    Hostname is the fully qualified domain name of the Connector node.
+                                    If MagicDNS is enabled in your tailnet, it is the MagicDNS name of the
+                                    node.
+                                type: string
+                            isExitNode:
+                                description: IsExitNode is set to true if the Connector acts as an exit node.
+                                type: boolean
+                            subnetRoutes:
+                                description: |-
+                                    SubnetRoutes are the routes currently exposed to tailnet via this
+                                    Connector instance.
+                                type: string
+                            tailnetIPs:
+                                description: |-
+                                    TailnetIPs is the set of tailnet IP addresses (both IPv4 and IPv6)
+                                    assigned to the Connector node.
+                                items:
+                                    type: string
+                                type: array
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
+    name: dnsconfigs.tailscale.com
+spec:
+    group: tailscale.com
+    names:
+        kind: DNSConfig
+        listKind: DNSConfigList
+        plural: dnsconfigs
+        shortNames:
+            - dc
+        singular: dnsconfig
+    scope: Cluster
+    versions:
+        - additionalPrinterColumns:
+            - description: Service IP address of the nameserver
+              jsonPath: .status.nameserver.ip
+              name: NameserverIP
+              type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: |-
+                    DNSConfig can be deployed to cluster to make a subset of Tailscale MagicDNS
+                    names resolvable by cluster workloads. Use this if: A) you need to refer to
+                    tailnet services, exposed to cluster via Tailscale Kubernetes operator egress
+                    proxies by the MagicDNS names of those tailnet services (usually because the
+                    services run over HTTPS)
+                    B) you have exposed a cluster workload to the tailnet using Tailscale Ingress
+                    and you also want to refer to the workload from within the cluster over the
+                    Ingress's MagicDNS name (usually because you have some callback component
+                    that needs to use the same URL as that used by a non-cluster client on
+                    tailnet).
+                    When a DNSConfig is applied to a cluster, Tailscale Kubernetes operator will
+                    deploy a nameserver for ts.net DNS names and automatically populate it with records
+                    for any Tailscale egress or Ingress proxies deployed to that cluster.
+                    Currently you must manually update your cluster DNS configuration to add the
+                    IP address of the deployed nameserver as a ts.net stub nameserver.
+                    Instructions for how to do it:
+                    https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#configuration-of-stub-domain-and-upstream-nameserver-using-coredns (for CoreDNS),
+                    https://cloud.google.com/kubernetes-engine/docs/how-to/kube-dns (for kube-dns).
+                    Tailscale Kubernetes operator will write the address of a Service fronting
+                    the nameserver to dsnconfig.status.nameserver.ip.
+                    DNSConfig is a singleton - you must not create more than one.
+                    NB: if you want cluster workloads to be able to refer to Tailscale Ingress
+                    using its MagicDNS name, you must also annotate the Ingress resource with
+                    tailscale.com/experimental-forward-cluster-traffic-via-ingress annotation to
+                    ensure that the proxy created for the Ingress listens on its Pod IP address.
+                    NB: Clusters where Pods get assigned IPv6 addresses only are currently not supported.
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: |-
+                            Spec describes the desired DNS configuration.
+                            More info:
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                            nameserver:
+                                description: |-
+                                    Configuration for a nameserver that can resolve ts.net DNS names
+                                    associated with in-cluster proxies for Tailscale egress Services and
+                                    Tailscale Ingresses. The operator will always deploy this nameserver
+                                    when a DNSConfig is applied.
+                                properties:
+                                    image:
+                                        description: Nameserver image. Defaults to tailscale/k8s-nameserver:unstable.
+                                        properties:
+                                            repo:
+                                                description: Repo defaults to tailscale/k8s-nameserver.
+                                                type: string
+                                            tag:
+                                                description: Tag defaults to unstable.
+                                                type: string
+                                        type: object
+                                type: object
+                        required:
+                            - nameserver
+                        type: object
+                    status:
+                        description: |-
+                            Status describes the status of the DNSConfig. This is set
+                            and managed by the Tailscale operator.
+                        properties:
+                            conditions:
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - type
+                                x-kubernetes-list-type: map
+                            nameserver:
+                                description: Nameserver describes the status of nameserver cluster resources.
+                                properties:
+                                    ip:
+                                        description: |-
+                                            IP is the ClusterIP of the Service fronting the deployed ts.net nameserver.
+                                            Currently you must manually update your cluster DNS config to add
+                                            this address as a stub nameserver for ts.net for cluster workloads to be
+                                            able to resolve MagicDNS names associated with egress or Ingress
+                                            proxies.
+                                            The IP address will change if you delete and recreate the DNSConfig.
+                                        type: string
+                                type: object
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
+    name: proxyclasses.tailscale.com
+spec:
+    group: tailscale.com
+    names:
+        kind: ProxyClass
+        listKind: ProxyClassList
+        plural: proxyclasses
+        singular: proxyclass
+    scope: Cluster
+    versions:
+        - additionalPrinterColumns:
+            - description: Status of the ProxyClass.
+              jsonPath: .status.conditions[?(@.type == "ProxyClassReady")].reason
+              name: Status
+              type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                description: |-
+                    ProxyClass describes a set of configuration parameters that can be applied to
+                    proxy resources created by the Tailscale Kubernetes operator.
+                    To apply a given ProxyClass to resources created for a tailscale Ingress or
+                    Service, use tailscale.com/proxy-class=<proxyclass-name> label. To apply a
+                    given ProxyClass to resources created for a Connector, use
+                    connector.spec.proxyClass field.
+                    ProxyClass is a cluster scoped resource.
+                    More info:
+                    https://tailscale.com/kb/1445/kubernetes-operator-customization#cluster-resource-customization-using-proxyclass-custom-resource
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: |-
+                            Specification of the desired state of the ProxyClass resource.
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                            metrics:
+                                description: |-
+                                    Configuration for proxy metrics. Metrics are currently not supported
+                                    for egress proxies and for Ingress proxies that have been configured
+                                    with tailscale.com/experimental-forward-cluster-traffic-via-ingress
+                                    annotation. Note that the metrics are currently considered unstable
+                                    and will likely change in breaking ways in the future - we only
+                                    recommend that you use those for debugging purposes.
+                                properties:
+                                    enable:
+                                        description: |-
+                                            Setting enable to true will make the proxy serve Tailscale metrics
+                                            at <pod-ip>:9001/debug/metrics.
+                                            Defaults to false.
+                                        type: boolean
+                                required:
+                                    - enable
+                                type: object
+                            statefulSet:
+                                description: |-
+                                    Configuration parameters for the proxy's StatefulSet. Tailscale
+                                    Kubernetes operator deploys a StatefulSet for each of the user
+                                    configured proxies (Tailscale Ingress, Tailscale Service, Connector).
+                                properties:
+                                    annotations:
+                                        additionalProperties:
+                                            type: string
+                                        description: |-
+                                            Annotations that will be added to the StatefulSet created for the proxy.
+                                            Any Annotations specified here will be merged with the default annotations
+                                            applied to the StatefulSet by the Tailscale Kubernetes operator as
+                                            well as any other annotations that might have been applied by other
+                                            actors.
+                                            Annotations must be valid Kubernetes annotations.
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                                        type: object
+                                    labels:
+                                        additionalProperties:
+                                            type: string
+                                        description: |-
+                                            Labels that will be added to the StatefulSet created for the proxy.
+                                            Any labels specified here will be merged with the default labels
+                                            applied to the StatefulSet by the Tailscale Kubernetes operator as
+                                            well as any other labels that might have been applied by other
+                                            actors.
+                                            Label keys and values must be valid Kubernetes label keys and values.
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+                                        type: object
+                                    pod:
+                                        description: Configuration for the proxy Pod.
+                                        properties:
+                                            affinity:
+                                                description: |-
+                                                    Proxy Pod's affinity rules.
+                                                    By default, the Tailscale Kubernetes operator does not apply any affinity rules.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#affinity
+                                                properties:
+                                                    nodeAffinity:
+                                                        description: Describes node affinity scheduling rules for the pod.
+                                                        properties:
+                                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                    the affinity expressions specified by this field, but it may choose
+                                                                    a node that violates one or more of the expressions. The node that is
+                                                                    most preferred is the one with the greatest sum of weights, i.e.
+                                                                    for each node that meets all of the scheduling requirements (resource
+                                                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                                                    compute a sum by iterating through the elements of this field and adding
+                                                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                                    node(s) with the highest sum are the most preferred.
+                                                                items:
+                                                                    description: |-
+                                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                                    properties:
+                                                                        preference:
+                                                                            description: A node selector term, associated with the corresponding weight.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: A list of node selector requirements by node's labels.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchFields:
+                                                                                    description: A list of node selector requirements by node's fields.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        weight:
+                                                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                    required:
+                                                                        - preference
+                                                                        - weight
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    If the affinity requirements specified by this field are not met at
+                                                                    scheduling time, the pod will not be scheduled onto the node.
+                                                                    If the affinity requirements specified by this field cease to be met
+                                                                    at some point during pod execution (e.g. due to an update), the system
+                                                                    may or may not try to eventually evict the pod from its node.
+                                                                properties:
+                                                                    nodeSelectorTerms:
+                                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                                        items:
+                                                                            description: |-
+                                                                                A null or empty node selector term matches no objects. The requirements of
+                                                                                them are ANDed.
+                                                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: A list of node selector requirements by node's labels.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchFields:
+                                                                                    description: A list of node selector requirements by node's fields.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                required:
+                                                                    - nodeSelectorTerms
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                        type: object
+                                                    podAffinity:
+                                                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                        properties:
+                                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                    the affinity expressions specified by this field, but it may choose
+                                                                    a node that violates one or more of the expressions. The node that is
+                                                                    most preferred is the one with the greatest sum of weights, i.e.
+                                                                    for each node that meets all of the scheduling requirements (resource
+                                                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                                                    compute a sum by iterating through the elements of this field and adding
+                                                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                    node(s) with the highest sum are the most preferred.
+                                                                items:
+                                                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                    properties:
+                                                                        podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                                labelSelector:
+                                                                                    description: |-
+                                                                                        A label query over a set of resources, in this case pods.
+                                                                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                matchLabelKeys:
+                                                                                    description: |-
+                                                                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                mismatchLabelKeys:
+                                                                                    description: |-
+                                                                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                namespaceSelector:
+                                                                                    description: |-
+                                                                                        A label query over the set of namespaces that the term applies to.
+                                                                                        The term is applied to the union of the namespaces selected by this field
+                                                                                        and the ones listed in the namespaces field.
+                                                                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                        An empty selector ({}) matches all namespaces.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                namespaces:
+                                                                                    description: |-
+                                                                                        namespaces specifies a static list of namespace names that the term applies to.
+                                                                                        The term is applied to the union of the namespaces listed in this field
+                                                                                        and the ones selected by namespaceSelector.
+                                                                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                topologyKey:
+                                                                                    description: |-
+                                                                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                        selected pods is running.
+                                                                                        Empty topologyKey is not allowed.
+                                                                                    type: string
+                                                                            required:
+                                                                                - topologyKey
+                                                                            type: object
+                                                                        weight:
+                                                                            description: |-
+                                                                                weight associated with matching the corresponding podAffinityTerm,
+                                                                                in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                    required:
+                                                                        - podAffinityTerm
+                                                                        - weight
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    If the affinity requirements specified by this field are not met at
+                                                                    scheduling time, the pod will not be scheduled onto the node.
+                                                                    If the affinity requirements specified by this field cease to be met
+                                                                    at some point during pod execution (e.g. due to a pod label update), the
+                                                                    system may or may not try to eventually evict the pod from its node.
+                                                                    When there are multiple elements, the lists of nodes corresponding to each
+                                                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                items:
+                                                                    description: |-
+                                                                        Defines a set of pods (namely those matching the labelSelector
+                                                                        relative to the given namespace(s)) that this pod should be
+                                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                                        where co-located is defined as running on a node whose value of
+                                                                        the label with key <topologyKey> matches that of any node on which
+                                                                        a pod of the set of pods is running
+                                                                    properties:
+                                                                        labelSelector:
+                                                                            description: |-
+                                                                                A label query over a set of resources, in this case pods.
+                                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        matchLabelKeys:
+                                                                            description: |-
+                                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        mismatchLabelKeys:
+                                                                            description: |-
+                                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        namespaceSelector:
+                                                                            description: |-
+                                                                                A label query over the set of namespaces that the term applies to.
+                                                                                The term is applied to the union of the namespaces selected by this field
+                                                                                and the ones listed in the namespaces field.
+                                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        namespaces:
+                                                                            description: |-
+                                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                                The term is applied to the union of the namespaces listed in this field
+                                                                                and the ones selected by namespaceSelector.
+                                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        topologyKey:
+                                                                            description: |-
+                                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                selected pods is running.
+                                                                                Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                    required:
+                                                                        - topologyKey
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                        type: object
+                                                    podAntiAffinity:
+                                                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                        properties:
+                                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                    the anti-affinity expressions specified by this field, but it may choose
+                                                                    a node that violates one or more of the expressions. The node that is
+                                                                    most preferred is the one with the greatest sum of weights, i.e.
+                                                                    for each node that meets all of the scheduling requirements (resource
+                                                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                                    compute a sum by iterating through the elements of this field and adding
+                                                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                    node(s) with the highest sum are the most preferred.
+                                                                items:
+                                                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                    properties:
+                                                                        podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                                labelSelector:
+                                                                                    description: |-
+                                                                                        A label query over a set of resources, in this case pods.
+                                                                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                matchLabelKeys:
+                                                                                    description: |-
+                                                                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                mismatchLabelKeys:
+                                                                                    description: |-
+                                                                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                namespaceSelector:
+                                                                                    description: |-
+                                                                                        A label query over the set of namespaces that the term applies to.
+                                                                                        The term is applied to the union of the namespaces selected by this field
+                                                                                        and the ones listed in the namespaces field.
+                                                                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                        An empty selector ({}) matches all namespaces.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                namespaces:
+                                                                                    description: |-
+                                                                                        namespaces specifies a static list of namespace names that the term applies to.
+                                                                                        The term is applied to the union of the namespaces listed in this field
+                                                                                        and the ones selected by namespaceSelector.
+                                                                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                topologyKey:
+                                                                                    description: |-
+                                                                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                        selected pods is running.
+                                                                                        Empty topologyKey is not allowed.
+                                                                                    type: string
+                                                                            required:
+                                                                                - topologyKey
+                                                                            type: object
+                                                                        weight:
+                                                                            description: |-
+                                                                                weight associated with matching the corresponding podAffinityTerm,
+                                                                                in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                    required:
+                                                                        - podAffinityTerm
+                                                                        - weight
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    If the anti-affinity requirements specified by this field are not met at
+                                                                    scheduling time, the pod will not be scheduled onto the node.
+                                                                    If the anti-affinity requirements specified by this field cease to be met
+                                                                    at some point during pod execution (e.g. due to a pod label update), the
+                                                                    system may or may not try to eventually evict the pod from its node.
+                                                                    When there are multiple elements, the lists of nodes corresponding to each
+                                                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                items:
+                                                                    description: |-
+                                                                        Defines a set of pods (namely those matching the labelSelector
+                                                                        relative to the given namespace(s)) that this pod should be
+                                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                                        where co-located is defined as running on a node whose value of
+                                                                        the label with key <topologyKey> matches that of any node on which
+                                                                        a pod of the set of pods is running
+                                                                    properties:
+                                                                        labelSelector:
+                                                                            description: |-
+                                                                                A label query over a set of resources, in this case pods.
+                                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        matchLabelKeys:
+                                                                            description: |-
+                                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        mismatchLabelKeys:
+                                                                            description: |-
+                                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        namespaceSelector:
+                                                                            description: |-
+                                                                                A label query over the set of namespaces that the term applies to.
+                                                                                The term is applied to the union of the namespaces selected by this field
+                                                                                and the ones listed in the namespaces field.
+                                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        namespaces:
+                                                                            description: |-
+                                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                                The term is applied to the union of the namespaces listed in this field
+                                                                                and the ones selected by namespaceSelector.
+                                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        topologyKey:
+                                                                            description: |-
+                                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                selected pods is running.
+                                                                                Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                    required:
+                                                                        - topologyKey
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                        type: object
+                                                type: object
+                                            annotations:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Annotations that will be added to the proxy Pod.
+                                                    Any annotations specified here will be merged with the default
+                                                    annotations applied to the Pod by the Tailscale Kubernetes operator.
+                                                    Annotations must be valid Kubernetes annotations.
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                                                type: object
+                                            imagePullSecrets:
+                                                description: |-
+                                                    Proxy Pod's image pull Secrets.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+                                                items:
+                                                    description: |-
+                                                        LocalObjectReference contains enough information to let you locate the
+                                                        referenced object inside the same namespace.
+                                                    properties:
+                                                        name:
+                                                            default: ""
+                                                            description: |-
+                                                                Name of the referent.
+                                                                This field is effectively required, but due to backwards compatibility is
+                                                                allowed to be empty. Instances of this type with an empty value here are
+                                                                almost certainly wrong.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            type: string
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: array
+                                            labels:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Labels that will be added to the proxy Pod.
+                                                    Any labels specified here will be merged with the default labels
+                                                    applied to the Pod by the Tailscale Kubernetes operator.
+                                                    Label keys and values must be valid Kubernetes label keys and values.
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+                                                type: object
+                                            nodeName:
+                                                description: |-
+                                                    Proxy Pod's node name.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling
+                                                type: string
+                                            nodeSelector:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Proxy Pod's node selector.
+                                                    By default Tailscale Kubernetes operator does not apply any node
+                                                    selector.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling
+                                                type: object
+                                            securityContext:
+                                                description: |-
+                                                    Proxy Pod's security context.
+                                                    By default Tailscale Kubernetes operator does not apply any Pod
+                                                    security context.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-2
+                                                properties:
+                                                    appArmorProfile:
+                                                        description: |-
+                                                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        properties:
+                                                            localhostProfile:
+                                                                description: |-
+                                                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                                                    The profile must be preconfigured on the node to work.
+                                                                    Must match the loaded name of the profile.
+                                                                    Must be set if and only if type is "Localhost".
+                                                                type: string
+                                                            type:
+                                                                description: |-
+                                                                    type indicates which kind of AppArmor profile will be applied.
+                                                                    Valid options are:
+                                                                      Localhost - a profile pre-loaded on the node.
+                                                                      RuntimeDefault - the container runtime's default profile.
+                                                                      Unconfined - no AppArmor enforcement.
+                                                                type: string
+                                                        required:
+                                                            - type
+                                                        type: object
+                                                    fsGroup:
+                                                        description: |-
+                                                            A special supplemental group that applies to all containers in a pod.
+                                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                                            to be owned by the pod:
+
+                                                            1. The owning GID will be the FSGroup
+                                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                            3. The permission bits are OR'd with rw-rw----
+
+                                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        format: int64
+                                                        type: integer
+                                                    fsGroupChangePolicy:
+                                                        description: |-
+                                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                            before being exposed inside Pod. This field will only apply to
+                                                            volume types which support fsGroup based ownership(and permissions).
+                                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                            and emptydir.
+                                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        type: string
+                                                    runAsGroup:
+                                                        description: |-
+                                                            The GID to run the entrypoint of the container process.
+                                                            Uses runtime default if unset.
+                                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                            for that container.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        format: int64
+                                                        type: integer
+                                                    runAsNonRoot:
+                                                        description: |-
+                                                            Indicates that the container must run as a non-root user.
+                                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                                            If unset or false, no such validation will be performed.
+                                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                        type: boolean
+                                                    runAsUser:
+                                                        description: |-
+                                                            The UID to run the entrypoint of the container process.
+                                                            Defaults to user specified in image metadata if unspecified.
+                                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                            for that container.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        format: int64
+                                                        type: integer
+                                                    seLinuxOptions:
+                                                        description: |-
+                                                            The SELinux context to be applied to all containers.
+                                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                                            container.  May also be set in SecurityContext.  If set in
+                                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                            takes precedence for that container.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        properties:
+                                                            level:
+                                                                description: Level is SELinux level label that applies to the container.
+                                                                type: string
+                                                            role:
+                                                                description: Role is a SELinux role label that applies to the container.
+                                                                type: string
+                                                            type:
+                                                                description: Type is a SELinux type label that applies to the container.
+                                                                type: string
+                                                            user:
+                                                                description: User is a SELinux user label that applies to the container.
+                                                                type: string
+                                                        type: object
+                                                    seccompProfile:
+                                                        description: |-
+                                                            The seccomp options to use by the containers in this pod.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        properties:
+                                                            localhostProfile:
+                                                                description: |-
+                                                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                                                    The profile must be preconfigured on the node to work.
+                                                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                                type: string
+                                                            type:
+                                                                description: |-
+                                                                    type indicates which kind of seccomp profile will be applied.
+                                                                    Valid options are:
+
+                                                                    Localhost - a profile defined in a file on the node should be used.
+                                                                    RuntimeDefault - the container runtime default profile should be used.
+                                                                    Unconfined - no profile should be applied.
+                                                                type: string
+                                                        required:
+                                                            - type
+                                                        type: object
+                                                    supplementalGroups:
+                                                        description: |-
+                                                            A list of groups applied to the first process run in each container, in addition
+                                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                            defined in the container image for the uid of the container process. If unspecified,
+                                                            no additional groups are added to any container. Note that group memberships
+                                                            defined in the container image for the uid of the container process are still effective,
+                                                            even if they are not included in this list.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        items:
+                                                            format: int64
+                                                            type: integer
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    sysctls:
+                                                        description: |-
+                                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                            sysctls (by the container runtime) might fail to launch.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        items:
+                                                            description: Sysctl defines a kernel parameter to be set
+                                                            properties:
+                                                                name:
+                                                                    description: Name of a property to set
+                                                                    type: string
+                                                                value:
+                                                                    description: Value of a property to set
+                                                                    type: string
+                                                            required:
+                                                                - name
+                                                                - value
+                                                            type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    windowsOptions:
+                                                        description: |-
+                                                            The Windows specific settings applied to all containers.
+                                                            If unspecified, the options within a container's SecurityContext will be used.
+                                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                            Note that this field cannot be set when spec.os.name is linux.
+                                                        properties:
+                                                            gmsaCredentialSpec:
+                                                                description: |-
+                                                                    GMSACredentialSpec is where the GMSA admission webhook
+                                                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                                                type: string
+                                                            gmsaCredentialSpecName:
+                                                                description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                                type: string
+                                                            hostProcess:
+                                                                description: |-
+                                                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                                                    All of a Pod's containers must have the same effective HostProcess value
+                                                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                                type: boolean
+                                                            runAsUserName:
+                                                                description: |-
+                                                                    The UserName in Windows to run the entrypoint of the container process.
+                                                                    Defaults to the user specified in image metadata if unspecified.
+                                                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                type: string
+                                                        type: object
+                                                type: object
+                                            tailscaleContainer:
+                                                description: Configuration for the proxy container running tailscale.
+                                                properties:
+                                                    env:
+                                                        description: |-
+                                                            List of environment variables to set in the container.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables
+                                                            Note that environment variables provided here will take precedence
+                                                            over Tailscale-specific environment variables set by the operator,
+                                                            however running proxies with custom values for Tailscale environment
+                                                            variables (i.e TS_USERSPACE) is not recommended and might break in
+                                                            the future.
+                                                        items:
+                                                            properties:
+                                                                name:
+                                                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                                    pattern: ^[-._a-zA-Z][-._a-zA-Z0-9]*$
+                                                                    type: string
+                                                                value:
+                                                                    description: |-
+                                                                        Variable references $(VAR_NAME) are expanded using the previously defined
+                                                                         environment variables in the container and any service environment
+                                                                        variables. If a variable cannot be resolved, the reference in the input
+                                                                        string will be unchanged. Double $$ are reduced to a single $, which
+                                                                        allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                                                        produce the string literal "$(VAR_NAME)". Escaped references will never
+                                                                        be expanded, regardless of whether the variable exists or not. Defaults
+                                                                        to "".
+                                                                    type: string
+                                                            required:
+                                                                - name
+                                                            type: object
+                                                        type: array
+                                                    image:
+                                                        description: |-
+                                                            Container image name. By default images are pulled from
+                                                            docker.io/tailscale/tailscale, but the official images are also
+                                                            available at ghcr.io/tailscale/tailscale. Specifying image name here
+                                                            will override any proxy image values specified via the Kubernetes
+                                                            operator's Helm chart values or PROXY_IMAGE env var in the operator
+                                                            Deployment.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image
+                                                        type: string
+                                                    imagePullPolicy:
+                                                        description: |-
+                                                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image
+                                                        enum:
+                                                            - Always
+                                                            - Never
+                                                            - IfNotPresent
+                                                        type: string
+                                                    resources:
+                                                        description: |-
+                                                            Container resource requirements.
+                                                            By default Tailscale Kubernetes operator does not apply any resource
+                                                            requirements. The amount of resources required wil depend on the
+                                                            amount of resources the operator needs to parse, usage patterns and
+                                                            cluster size.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
+                                                        properties:
+                                                            claims:
+                                                                description: |-
+                                                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                                                    that are used by this container.
+
+                                                                    This is an alpha field and requires enabling the
+                                                                    DynamicResourceAllocation feature gate.
+
+                                                                    This field is immutable. It can only be set for containers.
+                                                                items:
+                                                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                                                    properties:
+                                                                        name:
+                                                                            description: |-
+                                                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                                                the Pod where this field is used. It makes that resource available
+                                                                                inside a container.
+                                                                            type: string
+                                                                    required:
+                                                                        - name
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-map-keys:
+                                                                    - name
+                                                                x-kubernetes-list-type: map
+                                                            limits:
+                                                                additionalProperties:
+                                                                    anyOf:
+                                                                        - type: integer
+                                                                        - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                description: |-
+                                                                    Limits describes the maximum amount of compute resources allowed.
+                                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                                type: object
+                                                            requests:
+                                                                additionalProperties:
+                                                                    anyOf:
+                                                                        - type: integer
+                                                                        - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                description: |-
+                                                                    Requests describes the minimum amount of compute resources required.
+                                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                                type: object
+                                                        type: object
+                                                    securityContext:
+                                                        description: |-
+                                                            Container security context.
+                                                            Security context specified here will override the security context by the operator.
+                                                            By default the operator:
+                                                            - sets 'privileged: true' for the init container
+                                                            - set NET_ADMIN capability for tailscale container for proxies that
+                                                            are created for Services or Connector.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
+                                                        properties:
+                                                            allowPrivilegeEscalation:
+                                                                description: |-
+                                                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                                                    privileges than its parent process. This bool directly controls if
+                                                                    the no_new_privs flag will be set on the container process.
+                                                                    AllowPrivilegeEscalation is true always when the container is:
+                                                                    1) run as Privileged
+                                                                    2) has CAP_SYS_ADMIN
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            appArmorProfile:
+                                                                description: |-
+                                                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                                                    overrides the pod's appArmorProfile.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    localhostProfile:
+                                                                        description: |-
+                                                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                                                            The profile must be preconfigured on the node to work.
+                                                                            Must match the loaded name of the profile.
+                                                                            Must be set if and only if type is "Localhost".
+                                                                        type: string
+                                                                    type:
+                                                                        description: |-
+                                                                            type indicates which kind of AppArmor profile will be applied.
+                                                                            Valid options are:
+                                                                              Localhost - a profile pre-loaded on the node.
+                                                                              RuntimeDefault - the container runtime's default profile.
+                                                                              Unconfined - no AppArmor enforcement.
+                                                                        type: string
+                                                                required:
+                                                                    - type
+                                                                type: object
+                                                            capabilities:
+                                                                description: |-
+                                                                    The capabilities to add/drop when running containers.
+                                                                    Defaults to the default set of capabilities granted by the container runtime.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    add:
+                                                                        description: Added capabilities
+                                                                        items:
+                                                                            description: Capability represent POSIX capabilities type
+                                                                            type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    drop:
+                                                                        description: Removed capabilities
+                                                                        items:
+                                                                            description: Capability represent POSIX capabilities type
+                                                                            type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                type: object
+                                                            privileged:
+                                                                description: |-
+                                                                    Run container in privileged mode.
+                                                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                                                    Defaults to false.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            procMount:
+                                                                description: |-
+                                                                    procMount denotes the type of proc mount to use for the containers.
+                                                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                                                    readonly paths and masked paths.
+                                                                    This requires the ProcMountType feature flag to be enabled.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: string
+                                                            readOnlyRootFilesystem:
+                                                                description: |-
+                                                                    Whether this container has a read-only root filesystem.
+                                                                    Default is false.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            runAsGroup:
+                                                                description: |-
+                                                                    The GID to run the entrypoint of the container process.
+                                                                    Uses runtime default if unset.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                format: int64
+                                                                type: integer
+                                                            runAsNonRoot:
+                                                                description: |-
+                                                                    Indicates that the container must run as a non-root user.
+                                                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                                                    If unset or false, no such validation will be performed.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                type: boolean
+                                                            runAsUser:
+                                                                description: |-
+                                                                    The UID to run the entrypoint of the container process.
+                                                                    Defaults to user specified in image metadata if unspecified.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                format: int64
+                                                                type: integer
+                                                            seLinuxOptions:
+                                                                description: |-
+                                                                    The SELinux context to be applied to the container.
+                                                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    level:
+                                                                        description: Level is SELinux level label that applies to the container.
+                                                                        type: string
+                                                                    role:
+                                                                        description: Role is a SELinux role label that applies to the container.
+                                                                        type: string
+                                                                    type:
+                                                                        description: Type is a SELinux type label that applies to the container.
+                                                                        type: string
+                                                                    user:
+                                                                        description: User is a SELinux user label that applies to the container.
+                                                                        type: string
+                                                                type: object
+                                                            seccompProfile:
+                                                                description: |-
+                                                                    The seccomp options to use by this container. If seccomp options are
+                                                                    provided at both the pod & container level, the container options
+                                                                    override the pod options.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    localhostProfile:
+                                                                        description: |-
+                                                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                                                            The profile must be preconfigured on the node to work.
+                                                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                                        type: string
+                                                                    type:
+                                                                        description: |-
+                                                                            type indicates which kind of seccomp profile will be applied.
+                                                                            Valid options are:
+
+                                                                            Localhost - a profile defined in a file on the node should be used.
+                                                                            RuntimeDefault - the container runtime default profile should be used.
+                                                                            Unconfined - no profile should be applied.
+                                                                        type: string
+                                                                required:
+                                                                    - type
+                                                                type: object
+                                                            windowsOptions:
+                                                                description: |-
+                                                                    The Windows specific settings applied to all containers.
+                                                                    If unspecified, the options from the PodSecurityContext will be used.
+                                                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is linux.
+                                                                properties:
+                                                                    gmsaCredentialSpec:
+                                                                        description: |-
+                                                                            GMSACredentialSpec is where the GMSA admission webhook
+                                                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                                                        type: string
+                                                                    gmsaCredentialSpecName:
+                                                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                                        type: string
+                                                                    hostProcess:
+                                                                        description: |-
+                                                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                                                            All of a Pod's containers must have the same effective HostProcess value
+                                                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                                        type: boolean
+                                                                    runAsUserName:
+                                                                        description: |-
+                                                                            The UserName in Windows to run the entrypoint of the container process.
+                                                                            Defaults to the user specified in image metadata if unspecified.
+                                                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                        type: string
+                                                                type: object
+                                                        type: object
+                                                type: object
+                                            tailscaleInitContainer:
+                                                description: Configuration for the proxy init container that enables forwarding.
+                                                properties:
+                                                    env:
+                                                        description: |-
+                                                            List of environment variables to set in the container.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables
+                                                            Note that environment variables provided here will take precedence
+                                                            over Tailscale-specific environment variables set by the operator,
+                                                            however running proxies with custom values for Tailscale environment
+                                                            variables (i.e TS_USERSPACE) is not recommended and might break in
+                                                            the future.
+                                                        items:
+                                                            properties:
+                                                                name:
+                                                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                                    pattern: ^[-._a-zA-Z][-._a-zA-Z0-9]*$
+                                                                    type: string
+                                                                value:
+                                                                    description: |-
+                                                                        Variable references $(VAR_NAME) are expanded using the previously defined
+                                                                         environment variables in the container and any service environment
+                                                                        variables. If a variable cannot be resolved, the reference in the input
+                                                                        string will be unchanged. Double $$ are reduced to a single $, which
+                                                                        allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                                                        produce the string literal "$(VAR_NAME)". Escaped references will never
+                                                                        be expanded, regardless of whether the variable exists or not. Defaults
+                                                                        to "".
+                                                                    type: string
+                                                            required:
+                                                                - name
+                                                            type: object
+                                                        type: array
+                                                    image:
+                                                        description: |-
+                                                            Container image name. By default images are pulled from
+                                                            docker.io/tailscale/tailscale, but the official images are also
+                                                            available at ghcr.io/tailscale/tailscale. Specifying image name here
+                                                            will override any proxy image values specified via the Kubernetes
+                                                            operator's Helm chart values or PROXY_IMAGE env var in the operator
+                                                            Deployment.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image
+                                                        type: string
+                                                    imagePullPolicy:
+                                                        description: |-
+                                                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image
+                                                        enum:
+                                                            - Always
+                                                            - Never
+                                                            - IfNotPresent
+                                                        type: string
+                                                    resources:
+                                                        description: |-
+                                                            Container resource requirements.
+                                                            By default Tailscale Kubernetes operator does not apply any resource
+                                                            requirements. The amount of resources required wil depend on the
+                                                            amount of resources the operator needs to parse, usage patterns and
+                                                            cluster size.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
+                                                        properties:
+                                                            claims:
+                                                                description: |-
+                                                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                                                    that are used by this container.
+
+                                                                    This is an alpha field and requires enabling the
+                                                                    DynamicResourceAllocation feature gate.
+
+                                                                    This field is immutable. It can only be set for containers.
+                                                                items:
+                                                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                                                    properties:
+                                                                        name:
+                                                                            description: |-
+                                                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                                                the Pod where this field is used. It makes that resource available
+                                                                                inside a container.
+                                                                            type: string
+                                                                    required:
+                                                                        - name
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-map-keys:
+                                                                    - name
+                                                                x-kubernetes-list-type: map
+                                                            limits:
+                                                                additionalProperties:
+                                                                    anyOf:
+                                                                        - type: integer
+                                                                        - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                description: |-
+                                                                    Limits describes the maximum amount of compute resources allowed.
+                                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                                type: object
+                                                            requests:
+                                                                additionalProperties:
+                                                                    anyOf:
+                                                                        - type: integer
+                                                                        - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                description: |-
+                                                                    Requests describes the minimum amount of compute resources required.
+                                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                                type: object
+                                                        type: object
+                                                    securityContext:
+                                                        description: |-
+                                                            Container security context.
+                                                            Security context specified here will override the security context by the operator.
+                                                            By default the operator:
+                                                            - sets 'privileged: true' for the init container
+                                                            - set NET_ADMIN capability for tailscale container for proxies that
+                                                            are created for Services or Connector.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
+                                                        properties:
+                                                            allowPrivilegeEscalation:
+                                                                description: |-
+                                                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                                                    privileges than its parent process. This bool directly controls if
+                                                                    the no_new_privs flag will be set on the container process.
+                                                                    AllowPrivilegeEscalation is true always when the container is:
+                                                                    1) run as Privileged
+                                                                    2) has CAP_SYS_ADMIN
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            appArmorProfile:
+                                                                description: |-
+                                                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                                                    overrides the pod's appArmorProfile.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    localhostProfile:
+                                                                        description: |-
+                                                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                                                            The profile must be preconfigured on the node to work.
+                                                                            Must match the loaded name of the profile.
+                                                                            Must be set if and only if type is "Localhost".
+                                                                        type: string
+                                                                    type:
+                                                                        description: |-
+                                                                            type indicates which kind of AppArmor profile will be applied.
+                                                                            Valid options are:
+                                                                              Localhost - a profile pre-loaded on the node.
+                                                                              RuntimeDefault - the container runtime's default profile.
+                                                                              Unconfined - no AppArmor enforcement.
+                                                                        type: string
+                                                                required:
+                                                                    - type
+                                                                type: object
+                                                            capabilities:
+                                                                description: |-
+                                                                    The capabilities to add/drop when running containers.
+                                                                    Defaults to the default set of capabilities granted by the container runtime.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    add:
+                                                                        description: Added capabilities
+                                                                        items:
+                                                                            description: Capability represent POSIX capabilities type
+                                                                            type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    drop:
+                                                                        description: Removed capabilities
+                                                                        items:
+                                                                            description: Capability represent POSIX capabilities type
+                                                                            type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                type: object
+                                                            privileged:
+                                                                description: |-
+                                                                    Run container in privileged mode.
+                                                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                                                    Defaults to false.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            procMount:
+                                                                description: |-
+                                                                    procMount denotes the type of proc mount to use for the containers.
+                                                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                                                    readonly paths and masked paths.
+                                                                    This requires the ProcMountType feature flag to be enabled.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: string
+                                                            readOnlyRootFilesystem:
+                                                                description: |-
+                                                                    Whether this container has a read-only root filesystem.
+                                                                    Default is false.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            runAsGroup:
+                                                                description: |-
+                                                                    The GID to run the entrypoint of the container process.
+                                                                    Uses runtime default if unset.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                format: int64
+                                                                type: integer
+                                                            runAsNonRoot:
+                                                                description: |-
+                                                                    Indicates that the container must run as a non-root user.
+                                                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                                                    If unset or false, no such validation will be performed.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                type: boolean
+                                                            runAsUser:
+                                                                description: |-
+                                                                    The UID to run the entrypoint of the container process.
+                                                                    Defaults to user specified in image metadata if unspecified.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                format: int64
+                                                                type: integer
+                                                            seLinuxOptions:
+                                                                description: |-
+                                                                    The SELinux context to be applied to the container.
+                                                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    level:
+                                                                        description: Level is SELinux level label that applies to the container.
+                                                                        type: string
+                                                                    role:
+                                                                        description: Role is a SELinux role label that applies to the container.
+                                                                        type: string
+                                                                    type:
+                                                                        description: Type is a SELinux type label that applies to the container.
+                                                                        type: string
+                                                                    user:
+                                                                        description: User is a SELinux user label that applies to the container.
+                                                                        type: string
+                                                                type: object
+                                                            seccompProfile:
+                                                                description: |-
+                                                                    The seccomp options to use by this container. If seccomp options are
+                                                                    provided at both the pod & container level, the container options
+                                                                    override the pod options.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    localhostProfile:
+                                                                        description: |-
+                                                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                                                            The profile must be preconfigured on the node to work.
+                                                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                                        type: string
+                                                                    type:
+                                                                        description: |-
+                                                                            type indicates which kind of seccomp profile will be applied.
+                                                                            Valid options are:
+
+                                                                            Localhost - a profile defined in a file on the node should be used.
+                                                                            RuntimeDefault - the container runtime default profile should be used.
+                                                                            Unconfined - no profile should be applied.
+                                                                        type: string
+                                                                required:
+                                                                    - type
+                                                                type: object
+                                                            windowsOptions:
+                                                                description: |-
+                                                                    The Windows specific settings applied to all containers.
+                                                                    If unspecified, the options from the PodSecurityContext will be used.
+                                                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is linux.
+                                                                properties:
+                                                                    gmsaCredentialSpec:
+                                                                        description: |-
+                                                                            GMSACredentialSpec is where the GMSA admission webhook
+                                                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                                                        type: string
+                                                                    gmsaCredentialSpecName:
+                                                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                                        type: string
+                                                                    hostProcess:
+                                                                        description: |-
+                                                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                                                            All of a Pod's containers must have the same effective HostProcess value
+                                                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                                        type: boolean
+                                                                    runAsUserName:
+                                                                        description: |-
+                                                                            The UserName in Windows to run the entrypoint of the container process.
+                                                                            Defaults to the user specified in image metadata if unspecified.
+                                                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                        type: string
+                                                                type: object
+                                                        type: object
+                                                type: object
+                                            tolerations:
+                                                description: |-
+                                                    Proxy Pod's tolerations.
+                                                    By default Tailscale Kubernetes operator does not apply any
+                                                    tolerations.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling
+                                                items:
+                                                    description: |-
+                                                        The pod this Toleration is attached to tolerates any taint that matches
+                                                        the triple <key,value,effect> using the matching operator <operator>.
+                                                    properties:
+                                                        effect:
+                                                            description: |-
+                                                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                            type: string
+                                                        key:
+                                                            description: |-
+                                                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                            type: string
+                                                        operator:
+                                                            description: |-
+                                                                Operator represents a key's relationship to the value.
+                                                                Valid operators are Exists and Equal. Defaults to Equal.
+                                                                Exists is equivalent to wildcard for value, so that a pod can
+                                                                tolerate all taints of a particular category.
+                                                            type: string
+                                                        tolerationSeconds:
+                                                            description: |-
+                                                                TolerationSeconds represents the period of time the toleration (which must be
+                                                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                                negative values will be treated as 0 (evict immediately) by the system.
+                                                            format: int64
+                                                            type: integer
+                                                        value:
+                                                            description: |-
+                                                                Value is the taint value the toleration matches to.
+                                                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                            type: string
+                                                    type: object
+                                                type: array
+                                        type: object
+                                type: object
+                            tailscale:
+                                description: |-
+                                    TailscaleConfig contains options to configure the tailscale-specific
+                                    parameters of proxies.
+                                properties:
+                                    acceptRoutes:
+                                        description: |-
+                                            AcceptRoutes can be set to true to make the proxy instance accept
+                                            routes advertized by other nodes on the tailnet, such as subnet
+                                            routes.
+                                            This is equivalent of passing --accept-routes flag to a tailscale Linux client.
+                                            https://tailscale.com/kb/1019/subnets#use-your-subnet-routes-from-other-devices
+                                            Defaults to false.
+                                        type: boolean
+                                type: object
+                        type: object
+                    status:
+                        description: |-
+                            Status of the ProxyClass. This is set and managed automatically.
+                            https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                        properties:
+                            conditions:
+                                description: |-
+                                    List of status conditions to indicate the status of the ProxyClass.
+                                    Known condition types are `ProxyClassReady`.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - type
+                                x-kubernetes-list-type: map
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
+    name: proxygroups.tailscale.com
+spec:
+    group: tailscale.com
+    names:
+        kind: ProxyGroup
+        listKind: ProxyGroupList
+        plural: proxygroups
+        shortNames:
+            - pg
+        singular: proxygroup
+    scope: Cluster
+    versions:
+        - additionalPrinterColumns:
+            - description: Status of the deployed ProxyGroup resources.
+              jsonPath: .status.conditions[?(@.type == "ProxyGroupReady")].reason
+              name: Status
+              type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: Spec describes the desired ProxyGroup instances.
+                        properties:
+                            hostnamePrefix:
+                                description: |-
+                                    HostnamePrefix is the hostname prefix to use for tailnet devices created
+                                    by the ProxyGroup. Each device will have the integer number from its
+                                    StatefulSet pod appended to this prefix to form the full hostname.
+                                    HostnamePrefix can contain lower case letters, numbers and dashes, it
+                                    must not start with a dash and must be between 1 and 62 characters long.
+                                pattern: ^[a-z0-9][a-z0-9-]{0,61}$
+                                type: string
+                            proxyClass:
+                                description: |-
+                                    ProxyClass is the name of the ProxyClass custom resource that contains
+                                    configuration options that should be applied to the resources created
+                                    for this ProxyGroup. If unset, and there is no default ProxyClass
+                                    configured, the operator will create resources with the default
+                                    configuration.
+                                type: string
+                            replicas:
+                                description: |-
+                                    Replicas specifies how many replicas to create the StatefulSet with.
+                                    Defaults to 2.
+                                format: int32
+                                type: integer
+                            tags:
+                                description: |-
+                                    Tags that the Tailscale devices will be tagged with. Defaults to [tag:k8s].
+                                    If you specify custom tags here, make sure you also make the operator
+                                    an owner of these tags.
+                                    See  https://tailscale.com/kb/1236/kubernetes-operator/#setting-up-the-kubernetes-operator.
+                                    Tags cannot be changed once a ProxyGroup device has been created.
+                                    Tag values must be in form ^tag:[a-zA-Z][a-zA-Z0-9-]*$.
+                                items:
+                                    pattern: ^tag:[a-zA-Z][a-zA-Z0-9-]*$
+                                    type: string
+                                type: array
+                            type:
+                                description: Type of the ProxyGroup proxies. Currently the only supported type is egress.
+                                enum:
+                                    - egress
+                                type: string
+                        required:
+                            - type
+                        type: object
+                    status:
+                        description: |-
+                            ProxyGroupStatus describes the status of the ProxyGroup resources. This is
+                            set and managed by the Tailscale operator.
+                        properties:
+                            conditions:
+                                description: |-
+                                    List of status conditions to indicate the status of the ProxyGroup
+                                    resources. Known condition types are `ProxyGroupReady`.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - type
+                                x-kubernetes-list-type: map
+                            devices:
+                                description: List of tailnet devices associated with the ProxyGroup StatefulSet.
+                                items:
+                                    properties:
+                                        hostname:
+                                            description: |-
+                                                Hostname is the fully qualified domain name of the device.
+                                                If MagicDNS is enabled in your tailnet, it is the MagicDNS name of the
+                                                node.
+                                            type: string
+                                        tailnetIPs:
+                                            description: |-
+                                                TailnetIPs is the set of tailnet IP addresses (both IPv4 and IPv6)
+                                                assigned to the device.
+                                            items:
+                                                type: string
+                                            type: array
+                                    required:
+                                        - hostname
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - hostname
+                                x-kubernetes-list-type: map
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+    annotations:
+        controller-gen.kubebuilder.io/version: v0.15.1-0.20240618033008-7824932b0cab
+    name: recorders.tailscale.com
+spec:
+    group: tailscale.com
+    names:
+        kind: Recorder
+        listKind: RecorderList
+        plural: recorders
+        shortNames:
+            - rec
+        singular: recorder
+    scope: Cluster
+    versions:
+        - additionalPrinterColumns:
+            - description: Status of the deployed Recorder resources.
+              jsonPath: .status.conditions[?(@.type == "RecorderReady")].reason
+              name: Status
+              type: string
+            - description: URL on which the UI is exposed if enabled.
+              jsonPath: .status.devices[?(@.url != "")].url
+              name: URL
+              type: string
+          name: v1alpha1
+          schema:
+            openAPIV3Schema:
+                properties:
+                    apiVersion:
+                        description: |-
+                            APIVersion defines the versioned schema of this representation of an object.
+                            Servers should convert recognized schemas to the latest internal value, and
+                            may reject unrecognized values.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+                        type: string
+                    kind:
+                        description: |-
+                            Kind is a string value representing the REST resource this object represents.
+                            Servers may infer this from the endpoint the client submits requests to.
+                            Cannot be updated.
+                            In CamelCase.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                        type: string
+                    metadata:
+                        type: object
+                    spec:
+                        description: Spec describes the desired recorder instance.
+                        properties:
+                            enableUI:
+                                description: |-
+                                    Set to true to enable the Recorder UI. The UI lists and plays recorded sessions.
+                                    The UI will be served at <MagicDNS name of the recorder>:443. Defaults to false.
+                                    Corresponds to --ui tsrecorder flag https://tailscale.com/kb/1246/tailscale-ssh-session-recording#deploy-a-recorder-node.
+                                    Required if S3 storage is not set up, to ensure that recordings are accessible.
+                                type: boolean
+                            statefulSet:
+                                description: |-
+                                    Configuration parameters for the Recorder's StatefulSet. The operator
+                                    deploys a StatefulSet for each Recorder resource.
+                                properties:
+                                    annotations:
+                                        additionalProperties:
+                                            type: string
+                                        description: |-
+                                            Annotations that will be added to the StatefulSet created for the Recorder.
+                                            Any Annotations specified here will be merged with the default annotations
+                                            applied to the StatefulSet by the operator.
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                                        type: object
+                                    labels:
+                                        additionalProperties:
+                                            type: string
+                                        description: |-
+                                            Labels that will be added to the StatefulSet created for the Recorder.
+                                            Any labels specified here will be merged with the default labels applied
+                                            to the StatefulSet by the operator.
+                                            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+                                        type: object
+                                    pod:
+                                        description: Configuration for pods created by the Recorder's StatefulSet.
+                                        properties:
+                                            affinity:
+                                                description: |-
+                                                    Affinity rules for Recorder Pods. By default, the operator does not
+                                                    apply any affinity rules.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#affinity
+                                                properties:
+                                                    nodeAffinity:
+                                                        description: Describes node affinity scheduling rules for the pod.
+                                                        properties:
+                                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                    the affinity expressions specified by this field, but it may choose
+                                                                    a node that violates one or more of the expressions. The node that is
+                                                                    most preferred is the one with the greatest sum of weights, i.e.
+                                                                    for each node that meets all of the scheduling requirements (resource
+                                                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                                                    compute a sum by iterating through the elements of this field and adding
+                                                                    "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                                    node(s) with the highest sum are the most preferred.
+                                                                items:
+                                                                    description: |-
+                                                                        An empty preferred scheduling term matches all objects with implicit weight 0
+                                                                        (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                                    properties:
+                                                                        preference:
+                                                                            description: A node selector term, associated with the corresponding weight.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: A list of node selector requirements by node's labels.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchFields:
+                                                                                    description: A list of node selector requirements by node's fields.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        weight:
+                                                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                    required:
+                                                                        - preference
+                                                                        - weight
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    If the affinity requirements specified by this field are not met at
+                                                                    scheduling time, the pod will not be scheduled onto the node.
+                                                                    If the affinity requirements specified by this field cease to be met
+                                                                    at some point during pod execution (e.g. due to an update), the system
+                                                                    may or may not try to eventually evict the pod from its node.
+                                                                properties:
+                                                                    nodeSelectorTerms:
+                                                                        description: Required. A list of node selector terms. The terms are ORed.
+                                                                        items:
+                                                                            description: |-
+                                                                                A null or empty node selector term matches no objects. The requirements of
+                                                                                them are ANDed.
+                                                                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: A list of node selector requirements by node's labels.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchFields:
+                                                                                    description: A list of node selector requirements by node's fields.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                                                            that relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: The label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    Represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    An array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. If the operator is Gt or Lt, the values
+                                                                                                    array must have a single element, which will be interpreted as an integer.
+                                                                                                    This array is replaced during a strategic merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                required:
+                                                                    - nodeSelectorTerms
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                        type: object
+                                                    podAffinity:
+                                                        description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                                        properties:
+                                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                    the affinity expressions specified by this field, but it may choose
+                                                                    a node that violates one or more of the expressions. The node that is
+                                                                    most preferred is the one with the greatest sum of weights, i.e.
+                                                                    for each node that meets all of the scheduling requirements (resource
+                                                                    request, requiredDuringScheduling affinity expressions, etc.),
+                                                                    compute a sum by iterating through the elements of this field and adding
+                                                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                    node(s) with the highest sum are the most preferred.
+                                                                items:
+                                                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                    properties:
+                                                                        podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                                labelSelector:
+                                                                                    description: |-
+                                                                                        A label query over a set of resources, in this case pods.
+                                                                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                matchLabelKeys:
+                                                                                    description: |-
+                                                                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                mismatchLabelKeys:
+                                                                                    description: |-
+                                                                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                namespaceSelector:
+                                                                                    description: |-
+                                                                                        A label query over the set of namespaces that the term applies to.
+                                                                                        The term is applied to the union of the namespaces selected by this field
+                                                                                        and the ones listed in the namespaces field.
+                                                                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                        An empty selector ({}) matches all namespaces.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                namespaces:
+                                                                                    description: |-
+                                                                                        namespaces specifies a static list of namespace names that the term applies to.
+                                                                                        The term is applied to the union of the namespaces listed in this field
+                                                                                        and the ones selected by namespaceSelector.
+                                                                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                topologyKey:
+                                                                                    description: |-
+                                                                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                        selected pods is running.
+                                                                                        Empty topologyKey is not allowed.
+                                                                                    type: string
+                                                                            required:
+                                                                                - topologyKey
+                                                                            type: object
+                                                                        weight:
+                                                                            description: |-
+                                                                                weight associated with matching the corresponding podAffinityTerm,
+                                                                                in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                    required:
+                                                                        - podAffinityTerm
+                                                                        - weight
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    If the affinity requirements specified by this field are not met at
+                                                                    scheduling time, the pod will not be scheduled onto the node.
+                                                                    If the affinity requirements specified by this field cease to be met
+                                                                    at some point during pod execution (e.g. due to a pod label update), the
+                                                                    system may or may not try to eventually evict the pod from its node.
+                                                                    When there are multiple elements, the lists of nodes corresponding to each
+                                                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                items:
+                                                                    description: |-
+                                                                        Defines a set of pods (namely those matching the labelSelector
+                                                                        relative to the given namespace(s)) that this pod should be
+                                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                                        where co-located is defined as running on a node whose value of
+                                                                        the label with key <topologyKey> matches that of any node on which
+                                                                        a pod of the set of pods is running
+                                                                    properties:
+                                                                        labelSelector:
+                                                                            description: |-
+                                                                                A label query over a set of resources, in this case pods.
+                                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        matchLabelKeys:
+                                                                            description: |-
+                                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        mismatchLabelKeys:
+                                                                            description: |-
+                                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        namespaceSelector:
+                                                                            description: |-
+                                                                                A label query over the set of namespaces that the term applies to.
+                                                                                The term is applied to the union of the namespaces selected by this field
+                                                                                and the ones listed in the namespaces field.
+                                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        namespaces:
+                                                                            description: |-
+                                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                                The term is applied to the union of the namespaces listed in this field
+                                                                                and the ones selected by namespaceSelector.
+                                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        topologyKey:
+                                                                            description: |-
+                                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                selected pods is running.
+                                                                                Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                    required:
+                                                                        - topologyKey
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                        type: object
+                                                    podAntiAffinity:
+                                                        description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                                        properties:
+                                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    The scheduler will prefer to schedule pods to nodes that satisfy
+                                                                    the anti-affinity expressions specified by this field, but it may choose
+                                                                    a node that violates one or more of the expressions. The node that is
+                                                                    most preferred is the one with the greatest sum of weights, i.e.
+                                                                    for each node that meets all of the scheduling requirements (resource
+                                                                    request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                                    compute a sum by iterating through the elements of this field and adding
+                                                                    "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                                    node(s) with the highest sum are the most preferred.
+                                                                items:
+                                                                    description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                                    properties:
+                                                                        podAffinityTerm:
+                                                                            description: Required. A pod affinity term, associated with the corresponding weight.
+                                                                            properties:
+                                                                                labelSelector:
+                                                                                    description: |-
+                                                                                        A label query over a set of resources, in this case pods.
+                                                                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                matchLabelKeys:
+                                                                                    description: |-
+                                                                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                        Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                mismatchLabelKeys:
+                                                                                    description: |-
+                                                                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                        be taken into consideration. The keys are used to lookup values from the
+                                                                                        incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                        to select the group of existing pods which pods will be taken into consideration
+                                                                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                        pod labels will be ignored. The default value is empty.
+                                                                                        The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                        Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                namespaceSelector:
+                                                                                    description: |-
+                                                                                        A label query over the set of namespaces that the term applies to.
+                                                                                        The term is applied to the union of the namespaces selected by this field
+                                                                                        and the ones listed in the namespaces field.
+                                                                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                        An empty selector ({}) matches all namespaces.
+                                                                                    properties:
+                                                                                        matchExpressions:
+                                                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                            items:
+                                                                                                description: |-
+                                                                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                                    relates the key and values.
+                                                                                                properties:
+                                                                                                    key:
+                                                                                                        description: key is the label key that the selector applies to.
+                                                                                                        type: string
+                                                                                                    operator:
+                                                                                                        description: |-
+                                                                                                            operator represents a key's relationship to a set of values.
+                                                                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                        type: string
+                                                                                                    values:
+                                                                                                        description: |-
+                                                                                                            values is an array of string values. If the operator is In or NotIn,
+                                                                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                            the values array must be empty. This array is replaced during a strategic
+                                                                                                            merge patch.
+                                                                                                        items:
+                                                                                                            type: string
+                                                                                                        type: array
+                                                                                                        x-kubernetes-list-type: atomic
+                                                                                                required:
+                                                                                                    - key
+                                                                                                    - operator
+                                                                                                type: object
+                                                                                            type: array
+                                                                                            x-kubernetes-list-type: atomic
+                                                                                        matchLabels:
+                                                                                            additionalProperties:
+                                                                                                type: string
+                                                                                            description: |-
+                                                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                            type: object
+                                                                                    type: object
+                                                                                    x-kubernetes-map-type: atomic
+                                                                                namespaces:
+                                                                                    description: |-
+                                                                                        namespaces specifies a static list of namespace names that the term applies to.
+                                                                                        The term is applied to the union of the namespaces listed in this field
+                                                                                        and the ones selected by namespaceSelector.
+                                                                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                                    items:
+                                                                                        type: string
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                topologyKey:
+                                                                                    description: |-
+                                                                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                        selected pods is running.
+                                                                                        Empty topologyKey is not allowed.
+                                                                                    type: string
+                                                                            required:
+                                                                                - topologyKey
+                                                                            type: object
+                                                                        weight:
+                                                                            description: |-
+                                                                                weight associated with matching the corresponding podAffinityTerm,
+                                                                                in the range 1-100.
+                                                                            format: int32
+                                                                            type: integer
+                                                                    required:
+                                                                        - podAffinityTerm
+                                                                        - weight
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                                                description: |-
+                                                                    If the anti-affinity requirements specified by this field are not met at
+                                                                    scheduling time, the pod will not be scheduled onto the node.
+                                                                    If the anti-affinity requirements specified by this field cease to be met
+                                                                    at some point during pod execution (e.g. due to a pod label update), the
+                                                                    system may or may not try to eventually evict the pod from its node.
+                                                                    When there are multiple elements, the lists of nodes corresponding to each
+                                                                    podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                                                items:
+                                                                    description: |-
+                                                                        Defines a set of pods (namely those matching the labelSelector
+                                                                        relative to the given namespace(s)) that this pod should be
+                                                                        co-located (affinity) or not co-located (anti-affinity) with,
+                                                                        where co-located is defined as running on a node whose value of
+                                                                        the label with key <topologyKey> matches that of any node on which
+                                                                        a pod of the set of pods is running
+                                                                    properties:
+                                                                        labelSelector:
+                                                                            description: |-
+                                                                                A label query over a set of resources, in this case pods.
+                                                                                If it's null, this PodAffinityTerm matches with no Pods.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        matchLabelKeys:
+                                                                            description: |-
+                                                                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        mismatchLabelKeys:
+                                                                            description: |-
+                                                                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                                                be taken into consideration. The keys are used to lookup values from the
+                                                                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                                                to select the group of existing pods which pods will be taken into consideration
+                                                                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                                                pod labels will be ignored. The default value is empty.
+                                                                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                                                This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        namespaceSelector:
+                                                                            description: |-
+                                                                                A label query over the set of namespaces that the term applies to.
+                                                                                The term is applied to the union of the namespaces selected by this field
+                                                                                and the ones listed in the namespaces field.
+                                                                                null selector and null or empty namespaces list means "this pod's namespace".
+                                                                                An empty selector ({}) matches all namespaces.
+                                                                            properties:
+                                                                                matchExpressions:
+                                                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                                                    items:
+                                                                                        description: |-
+                                                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                                            relates the key and values.
+                                                                                        properties:
+                                                                                            key:
+                                                                                                description: key is the label key that the selector applies to.
+                                                                                                type: string
+                                                                                            operator:
+                                                                                                description: |-
+                                                                                                    operator represents a key's relationship to a set of values.
+                                                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                                                type: string
+                                                                                            values:
+                                                                                                description: |-
+                                                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                                                    merge patch.
+                                                                                                items:
+                                                                                                    type: string
+                                                                                                type: array
+                                                                                                x-kubernetes-list-type: atomic
+                                                                                        required:
+                                                                                            - key
+                                                                                            - operator
+                                                                                        type: object
+                                                                                    type: array
+                                                                                    x-kubernetes-list-type: atomic
+                                                                                matchLabels:
+                                                                                    additionalProperties:
+                                                                                        type: string
+                                                                                    description: |-
+                                                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                                                    type: object
+                                                                            type: object
+                                                                            x-kubernetes-map-type: atomic
+                                                                        namespaces:
+                                                                            description: |-
+                                                                                namespaces specifies a static list of namespace names that the term applies to.
+                                                                                The term is applied to the union of the namespaces listed in this field
+                                                                                and the ones selected by namespaceSelector.
+                                                                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                                            items:
+                                                                                type: string
+                                                                            type: array
+                                                                            x-kubernetes-list-type: atomic
+                                                                        topologyKey:
+                                                                            description: |-
+                                                                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                                                                selected pods is running.
+                                                                                Empty topologyKey is not allowed.
+                                                                            type: string
+                                                                    required:
+                                                                        - topologyKey
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-type: atomic
+                                                        type: object
+                                                type: object
+                                            annotations:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Annotations that will be added to Recorder Pods. Any annotations
+                                                    specified here will be merged with the default annotations applied to
+                                                    the Pod by the operator.
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
+                                                type: object
+                                            container:
+                                                description: Configuration for the Recorder container running tailscale.
+                                                properties:
+                                                    env:
+                                                        description: |-
+                                                            List of environment variables to set in the container.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables
+                                                            Note that environment variables provided here will take precedence
+                                                            over Tailscale-specific environment variables set by the operator,
+                                                            however running proxies with custom values for Tailscale environment
+                                                            variables (i.e TS_USERSPACE) is not recommended and might break in
+                                                            the future.
+                                                        items:
+                                                            properties:
+                                                                name:
+                                                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                                    pattern: ^[-._a-zA-Z][-._a-zA-Z0-9]*$
+                                                                    type: string
+                                                                value:
+                                                                    description: |-
+                                                                        Variable references $(VAR_NAME) are expanded using the previously defined
+                                                                         environment variables in the container and any service environment
+                                                                        variables. If a variable cannot be resolved, the reference in the input
+                                                                        string will be unchanged. Double $$ are reduced to a single $, which
+                                                                        allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                                                        produce the string literal "$(VAR_NAME)". Escaped references will never
+                                                                        be expanded, regardless of whether the variable exists or not. Defaults
+                                                                        to "".
+                                                                    type: string
+                                                            required:
+                                                                - name
+                                                            type: object
+                                                        type: array
+                                                    image:
+                                                        description: |-
+                                                            Container image name including tag. Defaults to docker.io/tailscale/tsrecorder
+                                                            with the same tag as the operator, but the official images are also
+                                                            available at ghcr.io/tailscale/tsrecorder.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image
+                                                        type: string
+                                                    imagePullPolicy:
+                                                        description: |-
+                                                            Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#image
+                                                        enum:
+                                                            - Always
+                                                            - Never
+                                                            - IfNotPresent
+                                                        type: string
+                                                    resources:
+                                                        description: |-
+                                                            Container resource requirements.
+                                                            By default, the operator does not apply any resource requirements. The
+                                                            amount of resources required wil depend on the volume of recordings sent.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#resources
+                                                        properties:
+                                                            claims:
+                                                                description: |-
+                                                                    Claims lists the names of resources, defined in spec.resourceClaims,
+                                                                    that are used by this container.
+
+                                                                    This is an alpha field and requires enabling the
+                                                                    DynamicResourceAllocation feature gate.
+
+                                                                    This field is immutable. It can only be set for containers.
+                                                                items:
+                                                                    description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                                                    properties:
+                                                                        name:
+                                                                            description: |-
+                                                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                                                the Pod where this field is used. It makes that resource available
+                                                                                inside a container.
+                                                                            type: string
+                                                                    required:
+                                                                        - name
+                                                                    type: object
+                                                                type: array
+                                                                x-kubernetes-list-map-keys:
+                                                                    - name
+                                                                x-kubernetes-list-type: map
+                                                            limits:
+                                                                additionalProperties:
+                                                                    anyOf:
+                                                                        - type: integer
+                                                                        - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                description: |-
+                                                                    Limits describes the maximum amount of compute resources allowed.
+                                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                                type: object
+                                                            requests:
+                                                                additionalProperties:
+                                                                    anyOf:
+                                                                        - type: integer
+                                                                        - type: string
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                description: |-
+                                                                    Requests describes the minimum amount of compute resources required.
+                                                                    If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                                    otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                                    More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                                type: object
+                                                        type: object
+                                                    securityContext:
+                                                        description: |-
+                                                            Container security context. By default, the operator does not apply any
+                                                            container security context.
+                                                            https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context
+                                                        properties:
+                                                            allowPrivilegeEscalation:
+                                                                description: |-
+                                                                    AllowPrivilegeEscalation controls whether a process can gain more
+                                                                    privileges than its parent process. This bool directly controls if
+                                                                    the no_new_privs flag will be set on the container process.
+                                                                    AllowPrivilegeEscalation is true always when the container is:
+                                                                    1) run as Privileged
+                                                                    2) has CAP_SYS_ADMIN
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            appArmorProfile:
+                                                                description: |-
+                                                                    appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                                                    overrides the pod's appArmorProfile.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    localhostProfile:
+                                                                        description: |-
+                                                                            localhostProfile indicates a profile loaded on the node that should be used.
+                                                                            The profile must be preconfigured on the node to work.
+                                                                            Must match the loaded name of the profile.
+                                                                            Must be set if and only if type is "Localhost".
+                                                                        type: string
+                                                                    type:
+                                                                        description: |-
+                                                                            type indicates which kind of AppArmor profile will be applied.
+                                                                            Valid options are:
+                                                                              Localhost - a profile pre-loaded on the node.
+                                                                              RuntimeDefault - the container runtime's default profile.
+                                                                              Unconfined - no AppArmor enforcement.
+                                                                        type: string
+                                                                required:
+                                                                    - type
+                                                                type: object
+                                                            capabilities:
+                                                                description: |-
+                                                                    The capabilities to add/drop when running containers.
+                                                                    Defaults to the default set of capabilities granted by the container runtime.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    add:
+                                                                        description: Added capabilities
+                                                                        items:
+                                                                            description: Capability represent POSIX capabilities type
+                                                                            type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                    drop:
+                                                                        description: Removed capabilities
+                                                                        items:
+                                                                            description: Capability represent POSIX capabilities type
+                                                                            type: string
+                                                                        type: array
+                                                                        x-kubernetes-list-type: atomic
+                                                                type: object
+                                                            privileged:
+                                                                description: |-
+                                                                    Run container in privileged mode.
+                                                                    Processes in privileged containers are essentially equivalent to root on the host.
+                                                                    Defaults to false.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            procMount:
+                                                                description: |-
+                                                                    procMount denotes the type of proc mount to use for the containers.
+                                                                    The default is DefaultProcMount which uses the container runtime defaults for
+                                                                    readonly paths and masked paths.
+                                                                    This requires the ProcMountType feature flag to be enabled.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: string
+                                                            readOnlyRootFilesystem:
+                                                                description: |-
+                                                                    Whether this container has a read-only root filesystem.
+                                                                    Default is false.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                type: boolean
+                                                            runAsGroup:
+                                                                description: |-
+                                                                    The GID to run the entrypoint of the container process.
+                                                                    Uses runtime default if unset.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                format: int64
+                                                                type: integer
+                                                            runAsNonRoot:
+                                                                description: |-
+                                                                    Indicates that the container must run as a non-root user.
+                                                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                                                    If unset or false, no such validation will be performed.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                type: boolean
+                                                            runAsUser:
+                                                                description: |-
+                                                                    The UID to run the entrypoint of the container process.
+                                                                    Defaults to user specified in image metadata if unspecified.
+                                                                    May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                format: int64
+                                                                type: integer
+                                                            seLinuxOptions:
+                                                                description: |-
+                                                                    The SELinux context to be applied to the container.
+                                                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                                                    container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    level:
+                                                                        description: Level is SELinux level label that applies to the container.
+                                                                        type: string
+                                                                    role:
+                                                                        description: Role is a SELinux role label that applies to the container.
+                                                                        type: string
+                                                                    type:
+                                                                        description: Type is a SELinux type label that applies to the container.
+                                                                        type: string
+                                                                    user:
+                                                                        description: User is a SELinux user label that applies to the container.
+                                                                        type: string
+                                                                type: object
+                                                            seccompProfile:
+                                                                description: |-
+                                                                    The seccomp options to use by this container. If seccomp options are
+                                                                    provided at both the pod & container level, the container options
+                                                                    override the pod options.
+                                                                    Note that this field cannot be set when spec.os.name is windows.
+                                                                properties:
+                                                                    localhostProfile:
+                                                                        description: |-
+                                                                            localhostProfile indicates a profile defined in a file on the node should be used.
+                                                                            The profile must be preconfigured on the node to work.
+                                                                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                                            Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                                        type: string
+                                                                    type:
+                                                                        description: |-
+                                                                            type indicates which kind of seccomp profile will be applied.
+                                                                            Valid options are:
+
+                                                                            Localhost - a profile defined in a file on the node should be used.
+                                                                            RuntimeDefault - the container runtime default profile should be used.
+                                                                            Unconfined - no profile should be applied.
+                                                                        type: string
+                                                                required:
+                                                                    - type
+                                                                type: object
+                                                            windowsOptions:
+                                                                description: |-
+                                                                    The Windows specific settings applied to all containers.
+                                                                    If unspecified, the options from the PodSecurityContext will be used.
+                                                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                    Note that this field cannot be set when spec.os.name is linux.
+                                                                properties:
+                                                                    gmsaCredentialSpec:
+                                                                        description: |-
+                                                                            GMSACredentialSpec is where the GMSA admission webhook
+                                                                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                                            GMSA credential spec named by the GMSACredentialSpecName field.
+                                                                        type: string
+                                                                    gmsaCredentialSpecName:
+                                                                        description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                                        type: string
+                                                                    hostProcess:
+                                                                        description: |-
+                                                                            HostProcess determines if a container should be run as a 'Host Process' container.
+                                                                            All of a Pod's containers must have the same effective HostProcess value
+                                                                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                                            In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                                        type: boolean
+                                                                    runAsUserName:
+                                                                        description: |-
+                                                                            The UserName in Windows to run the entrypoint of the container process.
+                                                                            Defaults to the user specified in image metadata if unspecified.
+                                                                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                        type: string
+                                                                type: object
+                                                        type: object
+                                                type: object
+                                            imagePullSecrets:
+                                                description: |-
+                                                    Image pull Secrets for Recorder Pods.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#PodSpec
+                                                items:
+                                                    description: |-
+                                                        LocalObjectReference contains enough information to let you locate the
+                                                        referenced object inside the same namespace.
+                                                    properties:
+                                                        name:
+                                                            default: ""
+                                                            description: |-
+                                                                Name of the referent.
+                                                                This field is effectively required, but due to backwards compatibility is
+                                                                allowed to be empty. Instances of this type with an empty value here are
+                                                                almost certainly wrong.
+                                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            type: string
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                type: array
+                                            labels:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Labels that will be added to Recorder Pods. Any labels specified here
+                                                    will be merged with the default labels applied to the Pod by the operator.
+                                                    https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+                                                type: object
+                                            nodeSelector:
+                                                additionalProperties:
+                                                    type: string
+                                                description: |-
+                                                    Node selector rules for Recorder Pods. By default, the operator does
+                                                    not apply any node selector rules.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling
+                                                type: object
+                                            securityContext:
+                                                description: |-
+                                                    Security context for Recorder Pods. By default, the operator does not
+                                                    apply any Pod security context.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-2
+                                                properties:
+                                                    appArmorProfile:
+                                                        description: |-
+                                                            appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        properties:
+                                                            localhostProfile:
+                                                                description: |-
+                                                                    localhostProfile indicates a profile loaded on the node that should be used.
+                                                                    The profile must be preconfigured on the node to work.
+                                                                    Must match the loaded name of the profile.
+                                                                    Must be set if and only if type is "Localhost".
+                                                                type: string
+                                                            type:
+                                                                description: |-
+                                                                    type indicates which kind of AppArmor profile will be applied.
+                                                                    Valid options are:
+                                                                      Localhost - a profile pre-loaded on the node.
+                                                                      RuntimeDefault - the container runtime's default profile.
+                                                                      Unconfined - no AppArmor enforcement.
+                                                                type: string
+                                                        required:
+                                                            - type
+                                                        type: object
+                                                    fsGroup:
+                                                        description: |-
+                                                            A special supplemental group that applies to all containers in a pod.
+                                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                                            to be owned by the pod:
+
+                                                            1. The owning GID will be the FSGroup
+                                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                                            3. The permission bits are OR'd with rw-rw----
+
+                                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        format: int64
+                                                        type: integer
+                                                    fsGroupChangePolicy:
+                                                        description: |-
+                                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                                            before being exposed inside Pod. This field will only apply to
+                                                            volume types which support fsGroup based ownership(and permissions).
+                                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                                            and emptydir.
+                                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        type: string
+                                                    runAsGroup:
+                                                        description: |-
+                                                            The GID to run the entrypoint of the container process.
+                                                            Uses runtime default if unset.
+                                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                            for that container.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        format: int64
+                                                        type: integer
+                                                    runAsNonRoot:
+                                                        description: |-
+                                                            Indicates that the container must run as a non-root user.
+                                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                                            If unset or false, no such validation will be performed.
+                                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                        type: boolean
+                                                    runAsUser:
+                                                        description: |-
+                                                            The UID to run the entrypoint of the container process.
+                                                            Defaults to user specified in image metadata if unspecified.
+                                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                                            for that container.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        format: int64
+                                                        type: integer
+                                                    seLinuxOptions:
+                                                        description: |-
+                                                            The SELinux context to be applied to all containers.
+                                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                                            container.  May also be set in SecurityContext.  If set in
+                                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                                            takes precedence for that container.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        properties:
+                                                            level:
+                                                                description: Level is SELinux level label that applies to the container.
+                                                                type: string
+                                                            role:
+                                                                description: Role is a SELinux role label that applies to the container.
+                                                                type: string
+                                                            type:
+                                                                description: Type is a SELinux type label that applies to the container.
+                                                                type: string
+                                                            user:
+                                                                description: User is a SELinux user label that applies to the container.
+                                                                type: string
+                                                        type: object
+                                                    seccompProfile:
+                                                        description: |-
+                                                            The seccomp options to use by the containers in this pod.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        properties:
+                                                            localhostProfile:
+                                                                description: |-
+                                                                    localhostProfile indicates a profile defined in a file on the node should be used.
+                                                                    The profile must be preconfigured on the node to work.
+                                                                    Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                                    Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                                type: string
+                                                            type:
+                                                                description: |-
+                                                                    type indicates which kind of seccomp profile will be applied.
+                                                                    Valid options are:
+
+                                                                    Localhost - a profile defined in a file on the node should be used.
+                                                                    RuntimeDefault - the container runtime default profile should be used.
+                                                                    Unconfined - no profile should be applied.
+                                                                type: string
+                                                        required:
+                                                            - type
+                                                        type: object
+                                                    supplementalGroups:
+                                                        description: |-
+                                                            A list of groups applied to the first process run in each container, in addition
+                                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                                            defined in the container image for the uid of the container process. If unspecified,
+                                                            no additional groups are added to any container. Note that group memberships
+                                                            defined in the container image for the uid of the container process are still effective,
+                                                            even if they are not included in this list.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        items:
+                                                            format: int64
+                                                            type: integer
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    sysctls:
+                                                        description: |-
+                                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                                            sysctls (by the container runtime) might fail to launch.
+                                                            Note that this field cannot be set when spec.os.name is windows.
+                                                        items:
+                                                            description: Sysctl defines a kernel parameter to be set
+                                                            properties:
+                                                                name:
+                                                                    description: Name of a property to set
+                                                                    type: string
+                                                                value:
+                                                                    description: Value of a property to set
+                                                                    type: string
+                                                            required:
+                                                                - name
+                                                                - value
+                                                            type: object
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                    windowsOptions:
+                                                        description: |-
+                                                            The Windows specific settings applied to all containers.
+                                                            If unspecified, the options within a container's SecurityContext will be used.
+                                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                            Note that this field cannot be set when spec.os.name is linux.
+                                                        properties:
+                                                            gmsaCredentialSpec:
+                                                                description: |-
+                                                                    GMSACredentialSpec is where the GMSA admission webhook
+                                                                    (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                                    GMSA credential spec named by the GMSACredentialSpecName field.
+                                                                type: string
+                                                            gmsaCredentialSpecName:
+                                                                description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                                type: string
+                                                            hostProcess:
+                                                                description: |-
+                                                                    HostProcess determines if a container should be run as a 'Host Process' container.
+                                                                    All of a Pod's containers must have the same effective HostProcess value
+                                                                    (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                                    In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                                type: boolean
+                                                            runAsUserName:
+                                                                description: |-
+                                                                    The UserName in Windows to run the entrypoint of the container process.
+                                                                    Defaults to the user specified in image metadata if unspecified.
+                                                                    May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                                type: string
+                                                        type: object
+                                                type: object
+                                            tolerations:
+                                                description: |-
+                                                    Tolerations for Recorder Pods. By default, the operator does not apply
+                                                    any tolerations.
+                                                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#scheduling
+                                                items:
+                                                    description: |-
+                                                        The pod this Toleration is attached to tolerates any taint that matches
+                                                        the triple <key,value,effect> using the matching operator <operator>.
+                                                    properties:
+                                                        effect:
+                                                            description: |-
+                                                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                                            type: string
+                                                        key:
+                                                            description: |-
+                                                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                                            type: string
+                                                        operator:
+                                                            description: |-
+                                                                Operator represents a key's relationship to the value.
+                                                                Valid operators are Exists and Equal. Defaults to Equal.
+                                                                Exists is equivalent to wildcard for value, so that a pod can
+                                                                tolerate all taints of a particular category.
+                                                            type: string
+                                                        tolerationSeconds:
+                                                            description: |-
+                                                                TolerationSeconds represents the period of time the toleration (which must be
+                                                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                                                negative values will be treated as 0 (evict immediately) by the system.
+                                                            format: int64
+                                                            type: integer
+                                                        value:
+                                                            description: |-
+                                                                Value is the taint value the toleration matches to.
+                                                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                                            type: string
+                                                    type: object
+                                                type: array
+                                        type: object
+                                type: object
+                            storage:
+                                description: |-
+                                    Configure where to store session recordings. By default, recordings will
+                                    be stored in a local ephemeral volume, and will not be persisted past the
+                                    lifetime of a specific pod.
+                                properties:
+                                    s3:
+                                        description: |-
+                                            Configure an S3-compatible API for storage. Required if the UI is not
+                                            enabled, to ensure that recordings are accessible.
+                                        properties:
+                                            bucket:
+                                                description: |-
+                                                    Bucket name to write to. The bucket is expected to be used solely for
+                                                    recordings, as there is no stable prefix for written object names.
+                                                type: string
+                                            credentials:
+                                                description: |-
+                                                    Configure environment variable credentials for managing objects in the
+                                                    configured bucket. If not set, tsrecorder will try to acquire credentials
+                                                    first from the file system and then the STS API.
+                                                properties:
+                                                    secret:
+                                                        description: |-
+                                                            Use a Kubernetes Secret from the operator's namespace as the source of
+                                                            credentials.
+                                                        properties:
+                                                            name:
+                                                                description: |-
+                                                                    The name of a Kubernetes Secret in the operator's namespace that contains
+                                                                    credentials for writing to the configured bucket. Each key-value pair
+                                                                    from the secret's data will be mounted as an environment variable. It
+                                                                    should include keys for AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY if
+                                                                    using a static access key.
+                                                                type: string
+                                                        type: object
+                                                type: object
+                                            endpoint:
+                                                description: S3-compatible endpoint, e.g. s3.us-east-1.amazonaws.com.
+                                                type: string
+                                        type: object
+                                type: object
+                            tags:
+                                description: |-
+                                    Tags that the Tailscale device will be tagged with. Defaults to [tag:k8s].
+                                    If you specify custom tags here, make sure you also make the operator
+                                    an owner of these tags.
+                                    See  https://tailscale.com/kb/1236/kubernetes-operator/#setting-up-the-kubernetes-operator.
+                                    Tags cannot be changed once a Recorder node has been created.
+                                    Tag values must be in form ^tag:[a-zA-Z][a-zA-Z0-9-]*$.
+                                items:
+                                    pattern: ^tag:[a-zA-Z][a-zA-Z0-9-]*$
+                                    type: string
+                                type: array
+                        type: object
+                    status:
+                        description: |-
+                            RecorderStatus describes the status of the recorder. This is set
+                            and managed by the Tailscale operator.
+                        properties:
+                            conditions:
+                                description: |-
+                                    List of status conditions to indicate the status of the Recorder.
+                                    Known condition types are `RecorderReady`.
+                                items:
+                                    description: Condition contains details for one aspect of the current state of this API Resource.
+                                    properties:
+                                        lastTransitionTime:
+                                            description: |-
+                                                lastTransitionTime is the last time the condition transitioned from one status to another.
+                                                This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                            format: date-time
+                                            type: string
+                                        message:
+                                            description: |-
+                                                message is a human readable message indicating details about the transition.
+                                                This may be an empty string.
+                                            maxLength: 32768
+                                            type: string
+                                        observedGeneration:
+                                            description: |-
+                                                observedGeneration represents the .metadata.generation that the condition was set based upon.
+                                                For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                                                with respect to the current state of the instance.
+                                            format: int64
+                                            minimum: 0
+                                            type: integer
+                                        reason:
+                                            description: |-
+                                                reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                                                Producers of specific condition types may define expected values and meanings for this field,
+                                                and whether the values are considered a guaranteed API.
+                                                The value should be a CamelCase string.
+                                                This field may not be empty.
+                                            maxLength: 1024
+                                            minLength: 1
+                                            pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                            type: string
+                                        status:
+                                            description: status of the condition, one of True, False, Unknown.
+                                            enum:
+                                                - "True"
+                                                - "False"
+                                                - Unknown
+                                            type: string
+                                        type:
+                                            description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                                            maxLength: 316
+                                            pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                            type: string
+                                    required:
+                                        - lastTransitionTime
+                                        - message
+                                        - reason
+                                        - status
+                                        - type
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - type
+                                x-kubernetes-list-type: map
+                            devices:
+                                description: List of tailnet devices associated with the Recorder StatefulSet.
+                                items:
+                                    properties:
+                                        hostname:
+                                            description: |-
+                                                Hostname is the fully qualified domain name of the device.
+                                                If MagicDNS is enabled in your tailnet, it is the MagicDNS name of the
+                                                node.
+                                            type: string
+                                        tailnetIPs:
+                                            description: |-
+                                                TailnetIPs is the set of tailnet IP addresses (both IPv4 and IPv6)
+                                                assigned to the device.
+                                            items:
+                                                type: string
+                                            type: array
+                                        url:
+                                            description: |-
+                                                URL where the UI is available if enabled for replaying recordings. This
+                                                will be an HTTPS MagicDNS URL. You must be connected to the same tailnet
+                                                as the recorder to access it.
+                                            type: string
+                                    required:
+                                        - hostname
+                                    type: object
+                                type: array
+                                x-kubernetes-list-map-keys:
+                                    - hostname
+                                x-kubernetes-list-type: map
+                        type: object
+                required:
+                    - spec
+                type: object
+          served: true
+          storage: true
+          subresources:
+            status: {}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: tailscale-operator
+rules:
+    - apiGroups:
+        - ""
+      resources:
+        - events
+        - services
+        - services/status
+      verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - networking.k8s.io
+      resources:
+        - ingresses
+        - ingresses/status
+      verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - networking.k8s.io
+      resources:
+        - ingressclasses
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - tailscale.com
+      resources:
+        - connectors
+        - connectors/status
+        - proxyclasses
+        - proxyclasses/status
+        - proxygroups
+        - proxygroups/status
+      verbs:
+        - get
+        - list
+        - watch
+        - update
+    - apiGroups:
+        - tailscale.com
+      resources:
+        - dnsconfigs
+        - dnsconfigs/status
+      verbs:
+        - get
+        - list
+        - watch
+        - update
+    - apiGroups:
+        - tailscale.com
+      resources:
+        - recorders
+        - recorders/status
+      verbs:
+        - get
+        - list
+        - watch
+        - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+    name: tailscale-operator
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: tailscale-operator
+subjects:
+    - kind: ServiceAccount
+      name: operator
+      namespace: tailscale
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: operator
+    namespace: tailscale
+rules:
+    - apiGroups:
+        - ""
+      resources:
+        - secrets
+        - serviceaccounts
+        - configmaps
+      verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - ""
+      resources:
+        - pods
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - apps
+      resources:
+        - statefulsets
+        - deployments
+      verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+    - apiGroups:
+        - discovery.k8s.io
+      resources:
+        - endpointslices
+      verbs:
+        - get
+        - list
+        - watch
+        - create
+        - update
+        - deletecollection
+    - apiGroups:
+        - rbac.authorization.k8s.io
+      resources:
+        - roles
+        - rolebindings
+      verbs:
+        - get
+        - create
+        - patch
+        - update
+        - list
+        - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: proxies
+    namespace: tailscale
+rules:
+    - apiGroups:
+        - ""
+      resources:
+        - secrets
+      verbs:
+        - create
+        - delete
+        - deletecollection
+        - get
+        - list
+        - patch
+        - update
+        - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: operator
+    namespace: tailscale
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: operator
+subjects:
+    - kind: ServiceAccount
+      name: operator
+      namespace: tailscale
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: proxies
+    namespace: tailscale
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: proxies
+subjects:
+    - kind: ServiceAccount
+      name: proxies
+      namespace: tailscale
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: operator
+    namespace: tailscale
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: operator
+    strategy:
+        type: Recreate
+    template:
+        metadata:
+            labels:
+                app: operator
+        spec:
+            containers:
+                - env:
+                    - name: OPERATOR_INITIAL_TAGS
+                      value: tag:k8s-operator
+                    - name: OPERATOR_HOSTNAME
+                      value: tailscale-operator
+                    - name: OPERATOR_SECRET
+                      value: operator
+                    - name: OPERATOR_LOGGING
+                      value: info
+                    - name: OPERATOR_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                            fieldPath: metadata.namespace
+                    - name: CLIENT_ID_FILE
+                      value: /oauth/client_id
+                    - name: CLIENT_SECRET_FILE
+                      value: /oauth/client_secret
+                    - name: PROXY_IMAGE
+                      value: tailscale/tailscale:unstable
+                    - name: PROXY_TAGS
+                      value: tag:k8s
+                    - name: APISERVER_PROXY
+                      value: "false"
+                    - name: PROXY_FIREWALL_MODE
+                      value: auto
+                  image: tailscale/k8s-operator:unstable
+                  imagePullPolicy: Always
+                  name: operator
+                  volumeMounts:
+                    - mountPath: /oauth
+                      name: oauth
+                      readOnly: true
+            nodeSelector:
+                kubernetes.io/os: linux
+            serviceAccountName: operator
+            volumes:
+                - name: oauth
+                  secret:
+                    secretName: operator-oauth
+---
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+    annotations: {}
+    name: tailscale
+spec:
+    controller: tailscale.com/ts-ingress

--- a/kubernetes/tailscale/rbac.yaml
+++ b/kubernetes/tailscale/rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tailscale
+  namespace: tailscale
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: tailscale-role
+  namespace: tailscale
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["tailscale-auth"] # name of tailscale secret (stored on cluster)
+  verbs: ["get", "update", "patch", "create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tailscale-role-binding
+  namespace: tailscale
+subjects:
+- kind: ServiceAccount
+  name: tailscale
+  namespace: tailscale
+roleRef:
+  kind: Role
+  name: tailscale-role
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/tailscale/tailscale-secret.yaml
+++ b/kubernetes/tailscale/tailscale-secret.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tailscale-auth
+stringData:
+  TS_AUTHKEY: <secret key>


### PR DESCRIPTION
# Description of changes made
- Successful set up of [Tailscale k8s operator](https://tailscale.com/kb/1236/kubernetes-operator)
- Access [Tailscale dashboard](https://login.tailscale.com/admin/machines)
- rbac, operator, and secret applied to cluster
- connection via non-home network currently made by editing server in .kube/config and skipping tls verification with `--insecure-skip-tls-verify=true`
