### PR TITLE
Coreos ssh

### DIFF
--- a/coreos-vm/README.md
+++ b/coreos-vm/README.md
@@ -12,9 +12,19 @@
 
 ## on mac to interact with vm
 
+By default, NAT networking does not allow inbound connections to the vm. To allow inbound SSH connections, you can forward connections to e.g. port 2222 on the host to the SSH server in the vm:
+
+`VBoxManage modifyvm coreos-vm --natpf1 "guestssh,tcp,,2222,,22"`
+
+Start and stop vm:
+
 `VBoxManage startvm coreos-vm` --type headless
 
 `VBoxManage controlvm coreos-vm acpipowerbutton`
+
+Connect with:
+
+`ssh core@localhost -p 2222`
 
 ## vm first boot
 
@@ -24,6 +34,7 @@ Fedora CoreOS will automatically apply the Ignition config from the secondary CD
 ## use container for ignition-validate to check the ignition file is valid
 
 -v $(pwd):/data mounts the current directory (where config.ign file is located) into /data inside the container
+
 `podman run --rm -v $(pwd):/data quay.io/coreos/ignition-validate:release /data/config.ign`
 
 ## use container for coreos-installer to inject ignition file into iso

--- a/coreos-vm/config.ign
+++ b/coreos-vm/config.ign
@@ -32,11 +32,6 @@
         "name": "hello.service"
       },
       {
-        "contents": "[Unit]\nDescription=Run single node etcd\nAfter=network-online.target\nWants=network-online.target\n\n[Service]\nExecStartPre=mkdir -p /var/lib/etcd\nExecStartPre=-/bin/podman kill etcd\nExecStartPre=-/bin/podman rm etcd\nExecStartPre=-/bin/podman pull quay.io/coreos/etcd\nExecStart=/bin/podman run --name etcd --volume /var/lib/etcd:/etcd-data:z --net=host quay.io/coreos/etcd:latest /usr/local/bin/etcd --data-dir /etcd-data --name node1 \\\n        --initial-advertise-peer-urls http://127.0.0.1:2380 --listen-peer-urls http://127.0.0.1:2380 \\\n        --advertise-client-urls http://127.0.0.1:2379 \\\n        --listen-client-urls http://127.0.0.1:2379 \\\n        --initial-cluster node1=http://127.0.0.1:2380\n\nExecStop=/bin/podman stop etcd\n\n[Install]\nWantedBy=multi-user.target\n",
-        "enabled": true,
-        "name": "etcd-member.service"
-      },
-      {
         "dropins": [
           {
             "contents": "[Service]\nEnvironmentFile=/etc/example-proxy.env\n",

--- a/coreos-vm/config.yaml
+++ b/coreos-vm/config.yaml
@@ -7,7 +7,6 @@ passwd:
         - ecdsa-sha2-nistp521 AAAAE2VjZHNhLXNoYTItbmlzdHA1MjEAAAAIbmlzdHA1MjEAAACFBAAok0q7jxMHMSUkp5vr6nzYB9A00gG8JZt41T+syFlft3Rv/LD4SswrhYiqAyfK3s+uGDobA8wwy7iUHrXAXAytqQHOU4bssijkJ73pGMZ6VqCBbH60PvXuvWwHS+VonPSndSSX4sQ1cGJjQdb86nLiAvIKfSFDgjUXYcMP7XZezM9eOg==
 systemd:
   units:
-    # Butane config for setting up a simple hello world service
     - name: hello.service
       enabled: true
       contents: |

--- a/coreos-vm/config.yaml
+++ b/coreos-vm/config.yaml
@@ -25,30 +25,6 @@ systemd:
 
         [Install]
         WantedBy=multi-user.target
-    # Butane config for setting up single node etcd
-    - name: etcd-member.service
-      enabled: true
-      contents: |
-        [Unit]
-        Description=Run single node etcd
-        After=network-online.target
-        Wants=network-online.target
-
-        [Service]
-        ExecStartPre=mkdir -p /var/lib/etcd
-        ExecStartPre=-/bin/podman kill etcd
-        ExecStartPre=-/bin/podman rm etcd
-        ExecStartPre=-/bin/podman pull quay.io/coreos/etcd
-        ExecStart=/bin/podman run --name etcd --volume /var/lib/etcd:/etcd-data:z --net=host quay.io/coreos/etcd:latest /usr/local/bin/etcd --data-dir /etcd-data --name node1 \
-                --initial-advertise-peer-urls http://127.0.0.1:2380 --listen-peer-urls http://127.0.0.1:2380 \
-                --advertise-client-urls http://127.0.0.1:2379 \
-                --listen-client-urls http://127.0.0.1:2379 \
-                --initial-cluster node1=http://127.0.0.1:2380
-
-        ExecStop=/bin/podman stop etcd
-
-        [Install]
-        WantedBy=multi-user.target
     - name: containerd.service
       enabled: true
       dropins:


### PR DESCRIPTION
# Description of changes made
- By default, NAT networking does not allow inbound connections to the vm. Allows inbound SSH connections by forwarding connections to port 2222 on the host to the SSH server in the vm. This command added to readme

## Does this PR address or close any existing issues?
- Allows ssh into vm without requiring password for `core` user
