### PR TITLE
feat(longhorn): apply manifests to k8s

### DIFF
--- a/kubernetes/longhorn/base/clusterrole.yaml
+++ b/kubernetes/longhorn/base/clusterrole.yaml
@@ -1,0 +1,178 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: longhorn-role
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - events
+      - persistentvolumes
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - nodes
+      - proxy/nodes
+      - pods/log
+      - secrets
+      - services
+      - endpoints
+      - configmaps
+      - serviceaccounts
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - statefulsets
+      - deployments
+    verbs:
+      - "*"
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+      - cronjobs
+    verbs:
+      - "*"
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+      - podsecuritypolicies
+    verbs:
+      - "*"
+  - apiGroups:
+      - scheduling.k8s.io
+    resources:
+      - priorityclasses
+    verbs:
+      - watch
+      - list
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+      - volumeattachments
+      - volumeattachments/status
+      - csinodes
+      - csidrivers
+    verbs:
+      - "*"
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshotclasses
+      - volumesnapshots
+      - volumesnapshotcontents
+      - volumesnapshotcontents/status
+    verbs:
+      - "*"
+  - apiGroups:
+      - longhorn.io
+    resources:
+      - volumes
+      - volumes/status
+      - engines
+      - engines/status
+      - replicas
+      - replicas/status
+      - settings
+      - settings/status
+      - engineimages
+      - engineimages/status
+      - nodes
+      - nodes/status
+      - instancemanagers
+      - instancemanagers/status
+      - sharemanagers
+      - sharemanagers/status
+      - backingimages
+      - backingimages/status
+      - backingimagemanagers
+      - backingimagemanagers/status
+      - backingimagedatasources
+      - backingimagedatasources/status
+      - backuptargets
+      - backuptargets/status
+      - backupvolumes
+      - backupvolumes/status
+      - backups
+      - backups/status
+      - recurringjobs
+      - recurringjobs/status
+      - orphans
+      - orphans/status
+      - snapshots
+      - snapshots/status
+      - supportbundles
+      - supportbundles/status
+      - systembackups
+      - systembackups/status
+      - systemrestores
+      - systemrestores/status
+      - volumeattachments
+      - volumeattachments/status
+      - backupbackingimages
+      - backupbackingimages/status
+    verbs:
+      - "*"
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - "*"
+  - apiGroups:
+      - metrics.k8s.io
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - apiregistration.k8s.io
+    resources:
+      - apiservices
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - mutatingwebhookconfigurations
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - delete
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
+      - clusterrolebindings
+      - clusterroles
+    verbs:
+      - "*"

--- a/kubernetes/longhorn/base/clusterrolebinding.yaml
+++ b/kubernetes/longhorn/base/clusterrolebinding.yaml
@@ -1,0 +1,33 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-bind
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: longhorn-role
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-service-account
+    namespace: longhorn-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: longhorn-support-bundle
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: longhorn-support-bundle
+    namespace: longhorn-system

--- a/kubernetes/longhorn/base/configmap.yaml
+++ b/kubernetes/longhorn/base/configmap.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-resource
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+data:
+  default-resource.yaml: ""
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-default-setting
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+data:
+  default-setting.yaml: |-
+    priority-class: longhorn-critical
+    disable-revision-counter: true
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: longhorn-storageclass
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+data:
+  storageclass.yaml: |
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      name: longhorn
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true"
+    provisioner: driver.longhorn.io
+    allowVolumeExpansion: true
+    reclaimPolicy: "Delete"
+    volumeBindingMode: Immediate
+    parameters:
+      numberOfReplicas: "3"
+      staleReplicaTimeout: "30"
+      fromBackup: ""
+      fsType: "ext4"
+      dataLocality: "disabled"
+      unmapMarkSnapChainRemoved: "ignored"
+      disableRevisionCounter: "true"
+      dataEngine: "v1"

--- a/kubernetes/longhorn/base/customresourcedefinition.yaml
+++ b/kubernetes/longhorn/base/customresourcedefinition.yaml
@@ -1,0 +1,4462 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backingimagedatasources.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackingImageDataSource
+    listKind: BackingImageDataSourceList
+    plural: backingimagedatasources
+    shortNames:
+      - lhbids
+    singular: backingimagedatasource
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The current state of the pod used to provision the backing image file from source
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The data source type
+          jsonPath: .spec.sourceType
+          name: SourceType
+          type: string
+        - description: The node the backing image file will be prepared on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The disk the backing image file will be prepared on
+          jsonPath: .spec.diskUUID
+          name: DiskUUID
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackingImageDataSource is where Longhorn stores backing image data source object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The system generated UUID of the provisioned backing image file
+          jsonPath: .spec.uuid
+          name: UUID
+          type: string
+        - description: The current state of the pod used to provision the backing image file from source
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The data source type
+          jsonPath: .spec.sourceType
+          name: SourceType
+          type: string
+        - description: The backing image file size
+          jsonPath: .status.size
+          name: Size
+          type: string
+        - description: The node the backing image file will be prepared on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The disk the backing image file will be prepared on
+          jsonPath: .spec.diskUUID
+          name: DiskUUID
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackingImageDataSource is where Longhorn stores backing image data source object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackingImageDataSourceSpec defines the desired state of the Longhorn backing image data source
+              properties:
+                checksum:
+                  type: string
+                diskPath:
+                  type: string
+                diskUUID:
+                  type: string
+                fileTransferred:
+                  type: boolean
+                nodeID:
+                  type: string
+                parameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                sourceType:
+                  enum:
+                    - download
+                    - upload
+                    - export-from-volume
+                    - restore
+                    - clone
+                  type: string
+                uuid:
+                  type: string
+              type: object
+            status:
+              description: BackingImageDataSourceStatus defines the observed state of the Longhorn backing image data source
+              properties:
+                checksum:
+                  type: string
+                currentState:
+                  type: string
+                ip:
+                  type: string
+                message:
+                  type: string
+                ownerID:
+                  type: string
+                progress:
+                  type: integer
+                runningParameters:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                size:
+                  format: int64
+                  type: integer
+                storageIP:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backingimagemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackingImageManager
+    listKind: BackingImageManagerList
+    plural: backingimagemanagers
+    shortNames:
+      - lhbim
+    singular: backingimagemanager
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The current state of the manager
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The image the manager pod will use
+          jsonPath: .spec.image
+          name: Image
+          type: string
+        - description: The node the manager is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The disk the manager is responsible for
+          jsonPath: .spec.diskUUID
+          name: DiskUUID
+          type: string
+        - description: The disk path the manager is using
+          jsonPath: .spec.diskPath
+          name: DiskPath
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackingImageManager is where Longhorn stores backing image manager object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The current state of the manager
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The image the manager pod will use
+          jsonPath: .spec.image
+          name: Image
+          type: string
+        - description: The node the manager is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The disk the manager is responsible for
+          jsonPath: .spec.diskUUID
+          name: DiskUUID
+          type: string
+        - description: The disk path the manager is using
+          jsonPath: .spec.diskPath
+          name: DiskPath
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackingImageManager is where Longhorn stores backing image manager object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackingImageManagerSpec defines the desired state of the Longhorn backing image manager
+              properties:
+                backingImages:
+                  additionalProperties:
+                    type: string
+                  type: object
+                diskPath:
+                  type: string
+                diskUUID:
+                  type: string
+                image:
+                  type: string
+                nodeID:
+                  type: string
+              type: object
+            status:
+              description: BackingImageManagerStatus defines the observed state of the Longhorn backing image manager
+              properties:
+                apiMinVersion:
+                  type: integer
+                apiVersion:
+                  type: integer
+                backingImageFileMap:
+                  additionalProperties:
+                    properties:
+                      currentChecksum:
+                        type: string
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      progress:
+                        type: integer
+                      realSize:
+                        format: int64
+                        type: integer
+                      senderManagerAddress:
+                        type: string
+                      sendingReference:
+                        type: integer
+                      size:
+                        format: int64
+                        type: integer
+                      state:
+                        type: string
+                      uuid:
+                        type: string
+                      virtualSize:
+                        format: int64
+                        type: integer
+                    type: object
+                  nullable: true
+                  type: object
+                currentState:
+                  type: string
+                ip:
+                  type: string
+                ownerID:
+                  type: string
+                storageIP:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backingimages.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+  group: longhorn.io
+  names:
+    kind: BackingImage
+    listKind: BackingImageList
+    plural: backingimages
+    shortNames:
+      - lhbi
+    singular: backingimage
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The backing image name
+          jsonPath: .spec.image
+          name: Image
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The system generated UUID
+          jsonPath: .status.uuid
+          name: UUID
+          type: string
+        - description: The source of the backing image file data
+          jsonPath: .spec.sourceType
+          name: SourceType
+          type: string
+        - description: The backing image file size in each disk
+          jsonPath: .status.size
+          name: Size
+          type: string
+        - description: The virtual size of the image (may be larger than file size)
+          jsonPath: .status.virtualSize
+          name: VirtualSize
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackingImage is where Longhorn stores backing image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackingImageSpec defines the desired state of the Longhorn backing image
+              properties:
+                checksum:
+                  type: string
+                dataEngine:
+                  default: v1
+                  enum:
+                    - v1
+                    - v2
+                  type: string
+                diskFileSpecMap:
+                  additionalProperties:
+                    properties:
+                      dataEngine:
+                        enum:
+                          - v1
+                          - v2
+                        type: string
+                      evictionRequested:
+                        type: boolean
+                    type: object
+                  type: object
+                diskSelector:
+                  items:
+                    type: string
+                  type: array
+                disks:
+                  additionalProperties:
+                    type: string
+                  description: Deprecated. We are now using DiskFileSpecMap to assign different spec to the file on different disks.
+                  type: object
+                minNumberOfCopies:
+                  type: integer
+                nodeSelector:
+                  items:
+                    type: string
+                  type: array
+                secret:
+                  type: string
+                secretNamespace:
+                  type: string
+                sourceParameters:
+                  additionalProperties:
+                    type: string
+                  type: object
+                sourceType:
+                  enum:
+                    - download
+                    - upload
+                    - export-from-volume
+                    - restore
+                    - clone
+                  type: string
+              type: object
+            status:
+              description: BackingImageStatus defines the observed state of the Longhorn backing image status
+              properties:
+                checksum:
+                  type: string
+                diskFileStatusMap:
+                  additionalProperties:
+                    properties:
+                      dataEngine:
+                        enum:
+                          - v1
+                          - v2
+                        type: string
+                      lastStateTransitionTime:
+                        type: string
+                      message:
+                        type: string
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                diskLastRefAtMap:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                ownerID:
+                  type: string
+                realSize:
+                  description: Real size of image in bytes, which may be smaller than the size when the file is a sparse file. Will be zero until known (e.g. while a backing image is uploading)
+                  format: int64
+                  type: integer
+                size:
+                  format: int64
+                  type: integer
+                uuid:
+                  type: string
+                v2FirstCopyDisk:
+                  type: string
+                v2FirstCopyStatus:
+                  description: It is pending -> in-progress -> ready/failed
+                  type: string
+                virtualSize:
+                  description: Virtual size of image in bytes, which may be larger than physical size. Will be zero until known (e.g. while a backing image is uploading)
+                  format: int64
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backupbackingimages.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackupBackingImage
+    listKind: BackupBackingImageList
+    plural: backupbackingimages
+    shortNames:
+      - lhbbi
+    singular: backupbackingimage
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The backing image name
+          jsonPath: .status.backingImage
+          name: BackingImage
+          type: string
+        - description: The backing image size
+          jsonPath: .status.size
+          name: Size
+          type: string
+        - description: The backing image backup upload finished time
+          jsonPath: .status.backupCreatedAt
+          name: BackupCreatedAt
+          type: string
+        - description: The backing image backup state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackupBackingImage is where Longhorn stores backing image backup object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackupBackingImageSpec defines the desired state of the Longhorn backing image backup
+              properties:
+                backingImage:
+                  description: The backing image name.
+                  type: string
+                backupTargetName:
+                  description: The backup target name.
+                  nullable: true
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The labels of backing image backup.
+                  type: object
+                syncRequestedAt:
+                  description: The time to request run sync the remote backing image backup.
+                  format: date-time
+                  nullable: true
+                  type: string
+                userCreated:
+                  description: Is this CR created by user through API or UI.
+                  type: boolean
+              required:
+                - backingImage
+                - userCreated
+              type: object
+            status:
+              description: BackupBackingImageStatus defines the observed state of the Longhorn backing image backup
+              properties:
+                backingImage:
+                  description: The backing image name.
+                  type: string
+                backupCreatedAt:
+                  description: The backing image backup upload finished time.
+                  type: string
+                checksum:
+                  description: The checksum of the backing image.
+                  type: string
+                compressionMethod:
+                  description: Compression method
+                  type: string
+                error:
+                  description: The error message when taking the backing image backup.
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The labels of backing image backup.
+                  nullable: true
+                  type: object
+                lastSyncedAt:
+                  description: The last time that the backing image backup was synced with the remote backup target.
+                  format: date-time
+                  nullable: true
+                  type: string
+                managerAddress:
+                  description: The address of the backing image manager that runs backing image backup.
+                  type: string
+                messages:
+                  additionalProperties:
+                    type: string
+                  description: The error messages when listing or inspecting backing image backup.
+                  nullable: true
+                  type: object
+                ownerID:
+                  description: The node ID on which the controller is responsible to reconcile this CR.
+                  type: string
+                progress:
+                  description: The backing image backup progress.
+                  type: integer
+                secret:
+                  description: Record the secret if this backup backing image is encrypted
+                  type: string
+                secretNamespace:
+                  description: Record the secret namespace if this backup backing image is encrypted
+                  type: string
+                size:
+                  description: The backing image size.
+                  format: int64
+                  type: integer
+                state:
+                  description: |-
+                    The backing image backup creation state.
+                    Can be "", "InProgress", "Completed", "Error", "Unknown".
+                  type: string
+                url:
+                  description: The backing image backup URL.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backups.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Backup
+    listKind: BackupList
+    plural: backups
+    shortNames:
+      - lhb
+    singular: backup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The snapshot name
+          jsonPath: .status.snapshotName
+          name: SnapshotName
+          type: string
+        - description: The snapshot size
+          jsonPath: .status.size
+          name: SnapshotSize
+          type: string
+        - description: The snapshot creation time
+          jsonPath: .status.snapshotCreatedAt
+          name: SnapshotCreatedAt
+          type: string
+        - description: The backup state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The backup last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Backup is where Longhorn stores backup object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The snapshot name
+          jsonPath: .status.snapshotName
+          name: SnapshotName
+          type: string
+        - description: The snapshot size
+          jsonPath: .status.size
+          name: SnapshotSize
+          type: string
+        - description: The snapshot creation time
+          jsonPath: .status.snapshotCreatedAt
+          name: SnapshotCreatedAt
+          type: string
+        - description: The backup target name
+          jsonPath: .status.backupTargetName
+          name: BackupTarget
+          type: string
+        - description: The backup state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The backup last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Backup is where Longhorn stores backup object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackupSpec defines the desired state of the Longhorn backup
+              properties:
+                backupMode:
+                  description: |-
+                    The backup mode of this backup.
+                    Can be "full" or "incremental"
+                  enum:
+                    - full
+                    - incremental
+                    - ""
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The labels of snapshot backup.
+                  type: object
+                snapshotName:
+                  description: The snapshot name.
+                  type: string
+                syncRequestedAt:
+                  description: The time to request run sync the remote backup.
+                  format: date-time
+                  nullable: true
+                  type: string
+              type: object
+            status:
+              description: BackupStatus defines the observed state of the Longhorn backup
+              properties:
+                backupCreatedAt:
+                  description: The snapshot backup upload finished time.
+                  type: string
+                backupTargetName:
+                  description: The backup target name.
+                  type: string
+                compressionMethod:
+                  description: Compression method
+                  type: string
+                error:
+                  description: The error message when taking the snapshot backup.
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The labels of snapshot backup.
+                  nullable: true
+                  type: object
+                lastSyncedAt:
+                  description: The last time that the backup was synced with the remote backup target.
+                  format: date-time
+                  nullable: true
+                  type: string
+                messages:
+                  additionalProperties:
+                    type: string
+                  description: The error messages when calling longhorn engine on listing or inspecting backups.
+                  nullable: true
+                  type: object
+                newlyUploadDataSize:
+                  description: Size in bytes of newly uploaded data
+                  type: string
+                ownerID:
+                  description: The node ID on which the controller is responsible to reconcile this backup CR.
+                  type: string
+                progress:
+                  description: The snapshot backup progress.
+                  type: integer
+                reUploadedDataSize:
+                  description: Size in bytes of reuploaded data
+                  type: string
+                replicaAddress:
+                  description: The address of the replica that runs snapshot backup.
+                  type: string
+                size:
+                  description: The snapshot size.
+                  type: string
+                snapshotCreatedAt:
+                  description: The snapshot creation time.
+                  type: string
+                snapshotName:
+                  description: The snapshot name.
+                  type: string
+                state:
+                  description: |-
+                    The backup creation state.
+                    Can be "", "InProgress", "Completed", "Error", "Unknown".
+                  type: string
+                url:
+                  description: The snapshot backup URL.
+                  type: string
+                volumeBackingImageName:
+                  description: The volume's backing image name.
+                  type: string
+                volumeCreated:
+                  description: The volume creation time.
+                  type: string
+                volumeName:
+                  description: The volume name.
+                  type: string
+                volumeSize:
+                  description: The volume size.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backuptargets.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+  group: longhorn.io
+  names:
+    kind: BackupTarget
+    listKind: BackupTargetList
+    plural: backuptargets
+    shortNames:
+      - lhbt
+    singular: backuptarget
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The backup target URL
+          jsonPath: .spec.backupTargetURL
+          name: URL
+          type: string
+        - description: The backup target credential secret
+          jsonPath: .spec.credentialSecret
+          name: Credential
+          type: string
+        - description: The backup target poll interval
+          jsonPath: .spec.pollInterval
+          name: LastBackupAt
+          type: string
+        - description: Indicate whether the backup target is available or not
+          jsonPath: .status.available
+          name: Available
+          type: boolean
+        - description: The backup target last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackupTarget is where Longhorn stores backup target object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The backup target URL
+          jsonPath: .spec.backupTargetURL
+          name: URL
+          type: string
+        - description: The backup target credential secret
+          jsonPath: .spec.credentialSecret
+          name: Credential
+          type: string
+        - description: The backup target poll interval
+          jsonPath: .spec.pollInterval
+          name: LastBackupAt
+          type: string
+        - description: Indicate whether the backup target is available or not
+          jsonPath: .status.available
+          name: Available
+          type: boolean
+        - description: The backup target last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackupTarget is where Longhorn stores backup target object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackupTargetSpec defines the desired state of the Longhorn backup target
+              properties:
+                backupTargetURL:
+                  description: The backup target URL.
+                  type: string
+                credentialSecret:
+                  description: The backup target credential secret.
+                  type: string
+                pollInterval:
+                  description: The interval that the cluster needs to run sync with the backup target.
+                  type: string
+                syncRequestedAt:
+                  description: The time to request run sync the remote backup target.
+                  format: date-time
+                  nullable: true
+                  type: string
+              type: object
+            status:
+              description: BackupTargetStatus defines the observed state of the Longhorn backup target
+              properties:
+                available:
+                  description: Available indicates if the remote backup target is available or not.
+                  type: boolean
+                conditions:
+                  description: Records the reason on why the backup target is unavailable.
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                lastSyncedAt:
+                  description: The last time that the controller synced with the remote backup target.
+                  format: date-time
+                  nullable: true
+                  type: string
+                ownerID:
+                  description: The node ID on which the controller is responsible to reconcile this backup target CR.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: backupvolumes.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: BackupVolume
+    listKind: BackupVolumeList
+    plural: backupvolumes
+    shortNames:
+      - lhbv
+    singular: backupvolume
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The backup volume creation time
+          jsonPath: .status.createdAt
+          name: CreatedAt
+          type: string
+        - description: The backup volume last backup name
+          jsonPath: .status.lastBackupName
+          name: LastBackupName
+          type: string
+        - description: The backup volume last backup time
+          jsonPath: .status.lastBackupAt
+          name: LastBackupAt
+          type: string
+        - description: The backup volume last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: BackupVolume is where Longhorn stores backup volume object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The backup target name
+          jsonPath: .spec.backupTargetName
+          name: BackupTarget
+          type: string
+        - description: The backup volume creation time
+          jsonPath: .status.createdAt
+          name: CreatedAt
+          type: string
+        - description: The backup volume last backup name
+          jsonPath: .status.lastBackupName
+          name: LastBackupName
+          type: string
+        - description: The backup volume last backup time
+          jsonPath: .status.lastBackupAt
+          name: LastBackupAt
+          type: string
+        - description: The backup volume last synced time
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: BackupVolume is where Longhorn stores backup volume object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: BackupVolumeSpec defines the desired state of the Longhorn backup volume
+              properties:
+                backupTargetName:
+                  description: The backup target name that the backup volume was synced.
+                  nullable: true
+                  type: string
+                syncRequestedAt:
+                  description: The time to request run sync the remote backup volume.
+                  format: date-time
+                  nullable: true
+                  type: string
+                volumeName:
+                  description: The volume name that the backup volume was used to backup.
+                  type: string
+              type: object
+            status:
+              description: BackupVolumeStatus defines the observed state of the Longhorn backup volume
+              properties:
+                backingImageChecksum:
+                  description: the backing image checksum.
+                  type: string
+                backingImageName:
+                  description: The backing image name.
+                  type: string
+                createdAt:
+                  description: The backup volume creation time.
+                  type: string
+                dataStored:
+                  description: The backup volume block count.
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The backup volume labels.
+                  nullable: true
+                  type: object
+                lastBackupAt:
+                  description: The latest volume backup time.
+                  type: string
+                lastBackupName:
+                  description: The latest volume backup name.
+                  type: string
+                lastModificationTime:
+                  description: The backup volume config last modification time.
+                  format: date-time
+                  nullable: true
+                  type: string
+                lastSyncedAt:
+                  description: The last time that the backup volume was synced into the cluster.
+                  format: date-time
+                  nullable: true
+                  type: string
+                messages:
+                  additionalProperties:
+                    type: string
+                  description: The error messages when call longhorn engine on list or inspect backup volumes.
+                  nullable: true
+                  type: object
+                ownerID:
+                  description: The node ID on which the controller is responsible to reconcile this backup volume CR.
+                  type: string
+                size:
+                  description: The backup volume size.
+                  type: string
+                storageClassName:
+                  description: the storage class name of pv/pvc binding with the volume.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: engineimages.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+  group: longhorn.io
+  names:
+    kind: EngineImage
+    listKind: EngineImageList
+    plural: engineimages
+    shortNames:
+      - lhei
+    singular: engineimage
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: State of the engine image
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The Longhorn engine image
+          jsonPath: .spec.image
+          name: Image
+          type: string
+        - description: Number of resources using the engine image
+          jsonPath: .status.refCount
+          name: RefCount
+          type: integer
+        - description: The build date of the engine image
+          jsonPath: .status.buildDate
+          name: BuildDate
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: EngineImage is where Longhorn stores engine image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Compatibility of the engine image
+          jsonPath: .status.incompatible
+          name: Incompatible
+          type: boolean
+        - description: State of the engine image
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The Longhorn engine image
+          jsonPath: .spec.image
+          name: Image
+          type: string
+        - description: Number of resources using the engine image
+          jsonPath: .status.refCount
+          name: RefCount
+          type: integer
+        - description: The build date of the engine image
+          jsonPath: .status.buildDate
+          name: BuildDate
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: EngineImage is where Longhorn stores engine image object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: EngineImageSpec defines the desired state of the Longhorn engine image
+              properties:
+                image:
+                  minLength: 1
+                  type: string
+              required:
+                - image
+              type: object
+            status:
+              description: EngineImageStatus defines the observed state of the Longhorn engine image
+              properties:
+                buildDate:
+                  type: string
+                cliAPIMinVersion:
+                  type: integer
+                cliAPIVersion:
+                  type: integer
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                controllerAPIMinVersion:
+                  type: integer
+                controllerAPIVersion:
+                  type: integer
+                dataFormatMinVersion:
+                  type: integer
+                dataFormatVersion:
+                  type: integer
+                gitCommit:
+                  type: string
+                incompatible:
+                  type: boolean
+                noRefSince:
+                  type: string
+                nodeDeploymentMap:
+                  additionalProperties:
+                    type: boolean
+                  nullable: true
+                  type: object
+                ownerID:
+                  type: string
+                refCount:
+                  type: integer
+                state:
+                  type: string
+                version:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: engines.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Engine
+    listKind: EngineList
+    plural: engines
+    shortNames:
+      - lhe
+    singular: engine
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The current state of the engine
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The node that the engine is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The instance manager of the engine
+          jsonPath: .status.instanceManagerName
+          name: InstanceManager
+          type: string
+        - description: The current image of the engine
+          jsonPath: .status.currentImage
+          name: Image
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Engine is where Longhorn stores engine object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The data engine of the engine
+          jsonPath: .spec.dataEngine
+          name: Data Engine
+          type: string
+        - description: The current state of the engine
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The node that the engine is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The instance manager of the engine
+          jsonPath: .status.instanceManagerName
+          name: InstanceManager
+          type: string
+        - description: The current image of the engine
+          jsonPath: .status.currentImage
+          name: Image
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Engine is where Longhorn stores engine object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: EngineSpec defines the desired state of the Longhorn engine
+              properties:
+                active:
+                  type: boolean
+                backendStoreDriver:
+                  description: Deprecated:Replaced by field `dataEngine`.
+                  type: string
+                backupVolume:
+                  type: string
+                dataEngine:
+                  enum:
+                    - v1
+                    - v2
+                  type: string
+                desireState:
+                  type: string
+                disableFrontend:
+                  type: boolean
+                engineImage:
+                  description: "Deprecated: Replaced by field `image`."
+                  type: string
+                frontend:
+                  enum:
+                    - blockdev
+                    - iscsi
+                    - nvmf
+                    - ""
+                  type: string
+                image:
+                  type: string
+                logRequested:
+                  type: boolean
+                nodeID:
+                  type: string
+                replicaAddressMap:
+                  additionalProperties:
+                    type: string
+                  type: object
+                requestedBackupRestore:
+                  type: string
+                requestedDataSource:
+                  type: string
+                revisionCounterDisabled:
+                  type: boolean
+                salvageRequested:
+                  type: boolean
+                snapshotMaxCount:
+                  type: integer
+                snapshotMaxSize:
+                  format: int64
+                  type: string
+                unmapMarkSnapChainRemovedEnabled:
+                  type: boolean
+                upgradedReplicaAddressMap:
+                  additionalProperties:
+                    type: string
+                  type: object
+                volumeName:
+                  type: string
+                volumeSize:
+                  format: int64
+                  type: string
+              type: object
+            status:
+              description: EngineStatus defines the observed state of the Longhorn engine
+              properties:
+                backupStatus:
+                  additionalProperties:
+                    properties:
+                      backupURL:
+                        type: string
+                      error:
+                        type: string
+                      progress:
+                        type: integer
+                      replicaAddress:
+                        type: string
+                      snapshotName:
+                        type: string
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                cloneStatus:
+                  additionalProperties:
+                    properties:
+                      error:
+                        type: string
+                      fromReplicaAddress:
+                        type: string
+                      isCloning:
+                        type: boolean
+                      progress:
+                        type: integer
+                      snapshotName:
+                        type: string
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                currentImage:
+                  type: string
+                currentReplicaAddressMap:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                currentSize:
+                  format: int64
+                  type: string
+                currentState:
+                  type: string
+                endpoint:
+                  type: string
+                instanceManagerName:
+                  type: string
+                ip:
+                  type: string
+                isExpanding:
+                  type: boolean
+                lastExpansionError:
+                  type: string
+                lastExpansionFailedAt:
+                  type: string
+                lastRestoredBackup:
+                  type: string
+                logFetched:
+                  type: boolean
+                ownerID:
+                  type: string
+                port:
+                  type: integer
+                purgeStatus:
+                  additionalProperties:
+                    properties:
+                      error:
+                        type: string
+                      isPurging:
+                        type: boolean
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                rebuildStatus:
+                  additionalProperties:
+                    properties:
+                      error:
+                        type: string
+                      fromReplicaAddress:
+                        type: string
+                      isRebuilding:
+                        type: boolean
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                replicaModeMap:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                replicaTransitionTimeMap:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    ReplicaTransitionTimeMap records the time a replica in ReplicaModeMap transitions from one mode to another (or
+                    from not being in the ReplicaModeMap to being in it). This information is sometimes required by other controllers
+                    (e.g. the volume controller uses it to determine the correct value for replica.Spec.lastHealthyAt).
+                  type: object
+                restoreStatus:
+                  additionalProperties:
+                    properties:
+                      backupURL:
+                        type: string
+                      currentRestoringBackup:
+                        type: string
+                      error:
+                        type: string
+                      filename:
+                        type: string
+                      isRestoring:
+                        type: boolean
+                      lastRestored:
+                        type: string
+                      progress:
+                        type: integer
+                      state:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                salvageExecuted:
+                  type: boolean
+                snapshotMaxCount:
+                  type: integer
+                snapshotMaxSize:
+                  format: int64
+                  type: string
+                snapshots:
+                  additionalProperties:
+                    properties:
+                      children:
+                        additionalProperties:
+                          type: boolean
+                        nullable: true
+                        type: object
+                      created:
+                        type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        nullable: true
+                        type: object
+                      name:
+                        type: string
+                      parent:
+                        type: string
+                      removed:
+                        type: boolean
+                      size:
+                        type: string
+                      usercreated:
+                        type: boolean
+                    type: object
+                  nullable: true
+                  type: object
+                snapshotsError:
+                  type: string
+                started:
+                  type: boolean
+                storageIP:
+                  type: string
+                unmapMarkSnapChainRemovedEnabled:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: instancemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: InstanceManager
+    listKind: InstanceManagerList
+    plural: instancemanagers
+    shortNames:
+      - lhim
+    singular: instancemanager
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The state of the instance manager
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The type of the instance manager (engine or replica)
+          jsonPath: .spec.type
+          name: Type
+          type: string
+        - description: The node that the instance manager is running on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: InstanceManager is where Longhorn stores instance manager object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The data engine of the instance manager
+          jsonPath: .spec.dataEngine
+          name: Data Engine
+          type: string
+        - description: The state of the instance manager
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The type of the instance manager (engine or replica)
+          jsonPath: .spec.type
+          name: Type
+          type: string
+        - description: The node that the instance manager is running on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: InstanceManager is where Longhorn stores instance manager object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: InstanceManagerSpec defines the desired state of the Longhorn instance manager
+              properties:
+                dataEngine:
+                  type: string
+                dataEngineSpec:
+                  properties:
+                    v2:
+                      properties:
+                        cpuMask:
+                          type: string
+                      type: object
+                  type: object
+                image:
+                  type: string
+                nodeID:
+                  type: string
+                type:
+                  enum:
+                    - aio
+                    - engine
+                    - replica
+                  type: string
+              type: object
+            status:
+              description: InstanceManagerStatus defines the observed state of the Longhorn instance manager
+              properties:
+                apiMinVersion:
+                  type: integer
+                apiVersion:
+                  type: integer
+                backingImages:
+                  additionalProperties:
+                    properties:
+                      currentChecksum:
+                        type: string
+                      diskUUID:
+                        type: string
+                      message:
+                        type: string
+                      name:
+                        type: string
+                      progress:
+                        type: integer
+                      size:
+                        format: int64
+                        type: integer
+                      state:
+                        type: string
+                      uuid:
+                        type: string
+                    type: object
+                  nullable: true
+                  type: object
+                currentState:
+                  type: string
+                dataEngineStatus:
+                  properties:
+                    v2:
+                      properties:
+                        cpuMask:
+                          type: string
+                      type: object
+                  type: object
+                instanceEngines:
+                  additionalProperties:
+                    properties:
+                      spec:
+                        properties:
+                          backendStoreDriver:
+                            description: Deprecated:Replaced by field `dataEngine`.
+                            type: string
+                          dataEngine:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      status:
+                        properties:
+                          conditions:
+                            additionalProperties:
+                              type: boolean
+                            nullable: true
+                            type: object
+                          endpoint:
+                            type: string
+                          errorMsg:
+                            type: string
+                          listen:
+                            type: string
+                          portEnd:
+                            format: int32
+                            type: integer
+                          portStart:
+                            format: int32
+                            type: integer
+                          resourceVersion:
+                            format: int64
+                            type: integer
+                          state:
+                            type: string
+                          targetPortEnd:
+                            format: int32
+                            type: integer
+                          targetPortStart:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                    type: object
+                  nullable: true
+                  type: object
+                instanceReplicas:
+                  additionalProperties:
+                    properties:
+                      spec:
+                        properties:
+                          backendStoreDriver:
+                            description: Deprecated:Replaced by field `dataEngine`.
+                            type: string
+                          dataEngine:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      status:
+                        properties:
+                          conditions:
+                            additionalProperties:
+                              type: boolean
+                            nullable: true
+                            type: object
+                          endpoint:
+                            type: string
+                          errorMsg:
+                            type: string
+                          listen:
+                            type: string
+                          portEnd:
+                            format: int32
+                            type: integer
+                          portStart:
+                            format: int32
+                            type: integer
+                          resourceVersion:
+                            format: int64
+                            type: integer
+                          state:
+                            type: string
+                          targetPortEnd:
+                            format: int32
+                            type: integer
+                          targetPortStart:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                    type: object
+                  nullable: true
+                  type: object
+                instances:
+                  additionalProperties:
+                    properties:
+                      spec:
+                        properties:
+                          backendStoreDriver:
+                            description: Deprecated:Replaced by field `dataEngine`.
+                            type: string
+                          dataEngine:
+                            type: string
+                          name:
+                            type: string
+                        type: object
+                      status:
+                        properties:
+                          conditions:
+                            additionalProperties:
+                              type: boolean
+                            nullable: true
+                            type: object
+                          endpoint:
+                            type: string
+                          errorMsg:
+                            type: string
+                          listen:
+                            type: string
+                          portEnd:
+                            format: int32
+                            type: integer
+                          portStart:
+                            format: int32
+                            type: integer
+                          resourceVersion:
+                            format: int64
+                            type: integer
+                          state:
+                            type: string
+                          targetPortEnd:
+                            format: int32
+                            type: integer
+                          targetPortStart:
+                            format: int32
+                            type: integer
+                          type:
+                            type: string
+                        type: object
+                    type: object
+                  description: "Deprecated: Replaced by InstanceEngines and InstanceReplicas"
+                  nullable: true
+                  type: object
+                ip:
+                  type: string
+                ownerID:
+                  type: string
+                proxyApiMinVersion:
+                  type: integer
+                proxyApiVersion:
+                  type: integer
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: nodes.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+  group: longhorn.io
+  names:
+    kind: Node
+    listKind: NodeList
+    plural: nodes
+    shortNames:
+      - lhn
+    singular: node
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Indicate whether the node is ready
+          jsonPath: .status.conditions['Ready']['status']
+          name: Ready
+          type: string
+        - description: Indicate whether the user disabled/enabled replica scheduling for the node
+          jsonPath: .spec.allowScheduling
+          name: AllowScheduling
+          type: boolean
+        - description: Indicate whether Longhorn can schedule replicas on the node
+          jsonPath: .status.conditions['Schedulable']['status']
+          name: Schedulable
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Node is where Longhorn stores Longhorn node object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicate whether the node is ready
+          jsonPath: .status.conditions[?(@.type=='Ready')].status
+          name: Ready
+          type: string
+        - description: Indicate whether the user disabled/enabled replica scheduling for the node
+          jsonPath: .spec.allowScheduling
+          name: AllowScheduling
+          type: boolean
+        - description: Indicate whether Longhorn can schedule replicas on the node
+          jsonPath: .status.conditions[?(@.type=='Schedulable')].status
+          name: Schedulable
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Node is where Longhorn stores Longhorn node object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: NodeSpec defines the desired state of the Longhorn node
+              properties:
+                allowScheduling:
+                  type: boolean
+                disks:
+                  additionalProperties:
+                    properties:
+                      allowScheduling:
+                        type: boolean
+                      diskDriver:
+                        enum:
+                          - ""
+                          - auto
+                          - aio
+                        type: string
+                      diskType:
+                        enum:
+                          - filesystem
+                          - block
+                        type: string
+                      evictionRequested:
+                        type: boolean
+                      path:
+                        type: string
+                      storageReserved:
+                        format: int64
+                        type: integer
+                      tags:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: object
+                evictionRequested:
+                  type: boolean
+                instanceManagerCPURequest:
+                  type: integer
+                name:
+                  type: string
+                tags:
+                  items:
+                    type: string
+                  type: array
+              type: object
+            status:
+              description: NodeStatus defines the observed state of the Longhorn node
+              properties:
+                autoEvicting:
+                  type: boolean
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                diskStatus:
+                  additionalProperties:
+                    properties:
+                      conditions:
+                        items:
+                          properties:
+                            lastProbeTime:
+                              description: Last time we probed the condition.
+                              type: string
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from one status to another.
+                              type: string
+                            message:
+                              description: Human-readable message indicating details about last transition.
+                              type: string
+                            reason:
+                              description: Unique, one-word, CamelCase reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: |-
+                                Status is the status of the condition.
+                                Can be True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type is the type of the condition.
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                      diskDriver:
+                        type: string
+                      diskName:
+                        type: string
+                      diskPath:
+                        type: string
+                      diskType:
+                        type: string
+                      diskUUID:
+                        type: string
+                      filesystemType:
+                        type: string
+                      instanceManagerName:
+                        type: string
+                      scheduledBackingImage:
+                        additionalProperties:
+                          format: int64
+                          type: integer
+                        nullable: true
+                        type: object
+                      scheduledReplica:
+                        additionalProperties:
+                          format: int64
+                          type: integer
+                        nullable: true
+                        type: object
+                      storageAvailable:
+                        format: int64
+                        type: integer
+                      storageMaximum:
+                        format: int64
+                        type: integer
+                      storageScheduled:
+                        format: int64
+                        type: integer
+                    type: object
+                  nullable: true
+                  type: object
+                region:
+                  type: string
+                snapshotCheckStatus:
+                  properties:
+                    lastPeriodicCheckedAt:
+                      format: date-time
+                      type: string
+                  type: object
+                zone:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: orphans.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Orphan
+    listKind: OrphanList
+    plural: orphans
+    shortNames:
+      - lho
+    singular: orphan
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The type of the orphan
+          jsonPath: .spec.orphanType
+          name: Type
+          type: string
+        - description: The node that the orphan is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Orphan is where Longhorn stores orphan object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OrphanSpec defines the desired state of the Longhorn orphaned data
+              properties:
+                nodeID:
+                  description: The node ID on which the controller is responsible to reconcile this orphan CR.
+                  type: string
+                orphanType:
+                  description: |-
+                    The type of the orphaned data.
+                    Can be "replica".
+                  type: string
+                parameters:
+                  additionalProperties:
+                    type: string
+                  description: The parameters of the orphaned data
+                  type: object
+              type: object
+            status:
+              description: OrphanStatus defines the observed state of the Longhorn orphaned data
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                ownerID:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: recurringjobs.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: RecurringJob
+    listKind: RecurringJobList
+    plural: recurringjobs
+    shortNames:
+      - lhrj
+    singular: recurringjob
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: Sets groupings to the jobs. When set to "default" group will be added to the volume label when no other job label exist in volume
+          jsonPath: .spec.groups
+          name: Groups
+          type: string
+        - description: Should be one of "backup" or "snapshot"
+          jsonPath: .spec.task
+          name: Task
+          type: string
+        - description: The cron expression represents recurring job scheduling
+          jsonPath: .spec.cron
+          name: Cron
+          type: string
+        - description: The number of snapshots/backups to keep for the volume
+          jsonPath: .spec.retain
+          name: Retain
+          type: integer
+        - description: The concurrent job to run by each cron job
+          jsonPath: .spec.concurrency
+          name: Concurrency
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Specify the labels
+          jsonPath: .spec.labels
+          name: Labels
+          type: string
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: RecurringJob is where Longhorn stores recurring job object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Sets groupings to the jobs. When set to "default" group will be added to the volume label when no other job label exist in volume
+          jsonPath: .spec.groups
+          name: Groups
+          type: string
+        - description: Should be one of "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup", "backup-force-create" or "filesystem-trim"
+          jsonPath: .spec.task
+          name: Task
+          type: string
+        - description: The cron expression represents recurring job scheduling
+          jsonPath: .spec.cron
+          name: Cron
+          type: string
+        - description: The number of snapshots/backups to keep for the volume
+          jsonPath: .spec.retain
+          name: Retain
+          type: integer
+        - description: The concurrent job to run by each cron job
+          jsonPath: .spec.concurrency
+          name: Concurrency
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - description: Specify the labels
+          jsonPath: .spec.labels
+          name: Labels
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: RecurringJob is where Longhorn stores recurring job object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RecurringJobSpec defines the desired state of the Longhorn recurring job
+              properties:
+                concurrency:
+                  description: The concurrency of taking the snapshot/backup.
+                  type: integer
+                cron:
+                  description: The cron setting.
+                  type: string
+                groups:
+                  description: The recurring job group.
+                  items:
+                    type: string
+                  type: array
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The label of the snapshot/backup.
+                  type: object
+                name:
+                  description: The recurring job name.
+                  type: string
+                parameters:
+                  additionalProperties:
+                    type: string
+                  description: |-
+                    The parameters of the snapshot/backup.
+                    Support parameters: "full-backup-interval".
+                  type: object
+                retain:
+                  description: The retain count of the snapshot/backup.
+                  type: integer
+                task:
+                  description: |-
+                    The recurring job task.
+                    Can be "snapshot", "snapshot-force-create", "snapshot-cleanup", "snapshot-delete", "backup", "backup-force-create" or "filesystem-trim"
+                  enum:
+                    - snapshot
+                    - snapshot-force-create
+                    - snapshot-cleanup
+                    - snapshot-delete
+                    - backup
+                    - backup-force-create
+                    - filesystem-trim
+                  type: string
+              type: object
+            status:
+              description: RecurringJobStatus defines the observed state of the Longhorn recurring job
+              properties:
+                executionCount:
+                  description: The number of jobs that have been triggered.
+                  type: integer
+                ownerID:
+                  description: The owner ID which is responsible to reconcile this recurring job CR.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: replicas.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Replica
+    listKind: ReplicaList
+    plural: replicas
+    shortNames:
+      - lhr
+    singular: replica
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The current state of the replica
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The node that the replica is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The disk that the replica is on
+          jsonPath: .spec.diskID
+          name: Disk
+          type: string
+        - description: The instance manager of the replica
+          jsonPath: .status.instanceManagerName
+          name: InstanceManager
+          type: string
+        - description: The current image of the replica
+          jsonPath: .status.currentImage
+          name: Image
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Replica is where Longhorn stores replica object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The data engine of the replica
+          jsonPath: .spec.dataEngine
+          name: Data Engine
+          type: string
+        - description: The current state of the replica
+          jsonPath: .status.currentState
+          name: State
+          type: string
+        - description: The node that the replica is on
+          jsonPath: .spec.nodeID
+          name: Node
+          type: string
+        - description: The disk that the replica is on
+          jsonPath: .spec.diskID
+          name: Disk
+          type: string
+        - description: The instance manager of the replica
+          jsonPath: .status.instanceManagerName
+          name: InstanceManager
+          type: string
+        - description: The current image of the replica
+          jsonPath: .status.currentImage
+          name: Image
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Replica is where Longhorn stores replica object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ReplicaSpec defines the desired state of the Longhorn replica
+              properties:
+                active:
+                  type: boolean
+                backendStoreDriver:
+                  description: Deprecated:Replaced by field `dataEngine`.
+                  type: string
+                backingImage:
+                  type: string
+                dataDirectoryName:
+                  type: string
+                dataEngine:
+                  enum:
+                    - v1
+                    - v2
+                  type: string
+                desireState:
+                  type: string
+                diskID:
+                  type: string
+                diskPath:
+                  type: string
+                engineImage:
+                  description: "Deprecated: Replaced by field `image`."
+                  type: string
+                engineName:
+                  type: string
+                evictionRequested:
+                  type: boolean
+                failedAt:
+                  description: |-
+                    FailedAt is set when a running replica fails or when a running engine is unable to use a replica for any reason.
+                    FailedAt indicates the time the failure occurred. When FailedAt is set, a replica is likely to have useful
+                    (though possibly stale) data. A replica with FailedAt set must be rebuilt from a non-failed replica (or it can
+                    be used in a salvage if all replicas are failed). FailedAt is cleared before a rebuild or salvage. FailedAt may
+                    be later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume
+                    controller acknowledges the change.
+                  type: string
+                hardNodeAffinity:
+                  type: string
+                healthyAt:
+                  description: |-
+                    HealthyAt is set the first time a replica becomes read/write in an engine after creation or rebuild. HealthyAt
+                    indicates the time the last successful rebuild occurred. When HealthyAt is set, a replica is likely to have
+                    useful (though possibly stale) data. HealthyAt is cleared before a rebuild. HealthyAt may be later than the
+                    corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller
+                    acknowledges the change.
+                  type: string
+                image:
+                  type: string
+                lastFailedAt:
+                  description: |-
+                    LastFailedAt is always set at the same time as FailedAt. Unlike FailedAt, LastFailedAt is never cleared.
+                    LastFailedAt is not a reliable indicator of the state of a replica's data. For example, a replica with
+                    LastFailedAt may already be healthy and in use again. However, because it is never cleared, it can be compared to
+                    LastHealthyAt to help prevent dangerous replica deletion in some corner cases. LastFailedAt may be later than the
+                    corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume controller
+                    acknowledges the change.
+                  type: string
+                lastHealthyAt:
+                  description: |-
+                    LastHealthyAt is set every time a replica becomes read/write in an engine. Unlike HealthyAt, LastHealthyAt is
+                    never cleared. LastHealthyAt is not a reliable indicator of the state of a replica's data. For example, a
+                    replica with LastHealthyAt set may be in the middle of a rebuild. However, because it is never cleared, it can be
+                    compared to LastFailedAt to help prevent dangerous replica deletion in some corner cases. LastHealthyAt may be
+                    later than the corresponding entry in an engine's replicaTransitionTimeMap because it is set when the volume
+                    controller acknowledges the change.
+                  type: string
+                logRequested:
+                  type: boolean
+                migrationEngineName:
+                  description: |-
+                    MigrationEngineName is indicating the migrating engine which current connected to this replica. This is only
+                    used for live migration of v2 data engine
+                  type: string
+                nodeID:
+                  type: string
+                rebuildRetryCount:
+                  type: integer
+                revisionCounterDisabled:
+                  type: boolean
+                salvageRequested:
+                  type: boolean
+                snapshotMaxCount:
+                  type: integer
+                snapshotMaxSize:
+                  format: int64
+                  type: string
+                unmapMarkDiskChainRemovedEnabled:
+                  type: boolean
+                volumeName:
+                  type: string
+                volumeSize:
+                  format: int64
+                  type: string
+              type: object
+            status:
+              description: ReplicaStatus defines the observed state of the Longhorn replica
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                currentImage:
+                  type: string
+                currentState:
+                  type: string
+                evictionRequested:
+                  description: "Deprecated: Replaced by field `spec.evictionRequested`."
+                  type: boolean
+                instanceManagerName:
+                  type: string
+                ip:
+                  type: string
+                logFetched:
+                  type: boolean
+                ownerID:
+                  type: string
+                port:
+                  type: integer
+                salvageExecuted:
+                  type: boolean
+                started:
+                  type: boolean
+                storageIP:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: settings.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Setting
+    listKind: SettingList
+    plural: settings
+    shortNames:
+      - lhs
+    singular: setting
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The value of the setting
+          jsonPath: .value
+          name: Value
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Setting is where Longhorn stores setting object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            value:
+              type: string
+          required:
+            - value
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The value of the setting
+          jsonPath: .value
+          name: Value
+          type: string
+        - description: The setting is applied
+          jsonPath: .status.applied
+          name: Applied
+          type: boolean
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Setting is where Longhorn stores setting object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            status:
+              description: The status of the setting.
+              properties:
+                applied:
+                  description: The setting is applied.
+                  type: boolean
+              required:
+                - applied
+              type: object
+            value:
+              description: The value of the setting.
+              type: string
+          required:
+            - value
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: sharemanagers.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: ShareManager
+    listKind: ShareManagerList
+    plural: sharemanagers
+    shortNames:
+      - lhsm
+    singular: sharemanager
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The state of the share manager
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The node that the share manager is owned by
+          jsonPath: .status.ownerID
+          name: Node
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: ShareManager is where Longhorn stores share manager object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The state of the share manager
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The node that the share manager is owned by
+          jsonPath: .status.ownerID
+          name: Node
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: ShareManager is where Longhorn stores share manager object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ShareManagerSpec defines the desired state of the Longhorn share manager
+              properties:
+                image:
+                  description: Share manager image used for creating a share manager pod
+                  type: string
+              type: object
+            status:
+              description: ShareManagerStatus defines the observed state of the Longhorn share manager
+              properties:
+                endpoint:
+                  description: NFS endpoint that can access the mounted filesystem of the volume
+                  type: string
+                ownerID:
+                  description: The node ID on which the controller is responsible to reconcile this share manager resource
+                  type: string
+                state:
+                  description: The state of the share manager resource
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: snapshots.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: Snapshot
+    listKind: SnapshotList
+    plural: snapshots
+    shortNames:
+      - lhsnap
+    singular: snapshot
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The volume that this snapshot belongs to
+          jsonPath: .spec.volume
+          name: Volume
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: string
+        - description: Indicates if the snapshot is ready to be used to restore/backup a volume
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The actual size of the snapshot
+          jsonPath: .status.size
+          name: Size
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Snapshot is the Schema for the snapshots API
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SnapshotSpec defines the desired state of Longhorn Snapshot
+              properties:
+                createSnapshot:
+                  description: require creating a new snapshot
+                  type: boolean
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: The labels of snapshot
+                  nullable: true
+                  type: object
+                volume:
+                  description: |-
+                    the volume that this snapshot belongs to.
+                    This field is immutable after creation.
+                  type: string
+              required:
+                - volume
+              type: object
+            status:
+              description: SnapshotStatus defines the observed state of Longhorn Snapshot
+              properties:
+                checksum:
+                  type: string
+                children:
+                  additionalProperties:
+                    type: boolean
+                  nullable: true
+                  type: object
+                creationTime:
+                  type: string
+                error:
+                  type: string
+                labels:
+                  additionalProperties:
+                    type: string
+                  nullable: true
+                  type: object
+                markRemoved:
+                  type: boolean
+                ownerID:
+                  type: string
+                parent:
+                  type: string
+                readyToUse:
+                  type: boolean
+                restoreSize:
+                  format: int64
+                  type: integer
+                size:
+                  format: int64
+                  type: integer
+                userCreated:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: supportbundles.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SupportBundle
+    listKind: SupportBundleList
+    plural: supportbundles
+    shortNames:
+      - lhbundle
+    singular: supportbundle
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The state of the support bundle
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The issue URL
+          jsonPath: .spec.issueURL
+          name: Issue
+          type: string
+        - description: A brief description of the issue
+          jsonPath: .spec.description
+          name: Description
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: SupportBundle is where Longhorn stores support bundle object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SupportBundleSpec defines the desired state of the Longhorn SupportBundle
+              properties:
+                description:
+                  description: A brief description of the issue
+                  type: string
+                issueURL:
+                  description: The issue URL
+                  nullable: true
+                  type: string
+                nodeID:
+                  description: The preferred responsible controller node ID.
+                  type: string
+              required:
+                - description
+              type: object
+            status:
+              description: SupportBundleStatus defines the observed state of the Longhorn SupportBundle
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  type: array
+                filename:
+                  type: string
+                filesize:
+                  format: int64
+                  type: integer
+                image:
+                  description: The support bundle manager image
+                  type: string
+                managerIP:
+                  description: The support bundle manager IP
+                  type: string
+                ownerID:
+                  description: The current responsible controller node ID
+                  type: string
+                progress:
+                  type: integer
+                state:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: systembackups.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SystemBackup
+    listKind: SystemBackupList
+    plural: systembackups
+    shortNames:
+      - lhsb
+    singular: systembackup
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The system backup Longhorn version
+          jsonPath: .status.version
+          name: Version
+          type: string
+        - description: The system backup state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The system backup creation time
+          jsonPath: .status.createdAt
+          name: Created
+          type: string
+        - description: The last time that the system backup was synced into the cluster
+          jsonPath: .status.lastSyncedAt
+          name: LastSyncedAt
+          type: string
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: SystemBackup is where Longhorn stores system backup object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SystemBackupSpec defines the desired state of the Longhorn SystemBackup
+              properties:
+                volumeBackupPolicy:
+                  description: |-
+                    The create volume backup policy
+                    Can be "if-not-present", "always" or "disabled"
+                  nullable: true
+                  type: string
+              type: object
+            status:
+              description: SystemBackupStatus defines the observed state of the Longhorn SystemBackup
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                createdAt:
+                  description: The system backup creation time.
+                  format: date-time
+                  type: string
+                gitCommit:
+                  description: The saved Longhorn manager git commit.
+                  nullable: true
+                  type: string
+                lastSyncedAt:
+                  description: The last time that the system backup was synced into the cluster.
+                  format: date-time
+                  nullable: true
+                  type: string
+                managerImage:
+                  description: The saved manager image.
+                  type: string
+                ownerID:
+                  description: The node ID of the responsible controller to reconcile this SystemBackup.
+                  type: string
+                state:
+                  description: The system backup state.
+                  type: string
+                version:
+                  description: The saved Longhorn version.
+                  nullable: true
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: systemrestores.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: SystemRestore
+    listKind: SystemRestoreList
+    plural: systemrestores
+    shortNames:
+      - lhsr
+    singular: systemrestore
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The system restore state
+          jsonPath: .status.state
+          name: State
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: SystemRestore is where Longhorn stores system restore object
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: SystemRestoreSpec defines the desired state of the Longhorn SystemRestore
+              properties:
+                systemBackup:
+                  description: The system backup name in the object store.
+                  type: string
+              required:
+                - systemBackup
+              type: object
+            status:
+              description: SystemRestoreStatus defines the observed state of the Longhorn SystemRestore
+              properties:
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                ownerID:
+                  description: The node ID of the responsible controller to reconcile this SystemRestore.
+                  type: string
+                sourceURL:
+                  description: The source system backup URL.
+                  type: string
+                state:
+                  description: The system restore state.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: volumeattachments.longhorn.io
+spec:
+  group: longhorn.io
+  names:
+    kind: VolumeAttachment
+    listKind: VolumeAttachmentList
+    plural: volumeattachments
+    shortNames:
+      - lhva
+    singular: volumeattachment
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: VolumeAttachment stores attachment information of a Longhorn volume
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VolumeAttachmentSpec defines the desired state of Longhorn VolumeAttachment
+              properties:
+                attachmentTickets:
+                  additionalProperties:
+                    properties:
+                      generation:
+                        description: |-
+                          A sequence number representing a specific generation of the desired state.
+                          Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      id:
+                        description: The unique ID of this attachment. Used to differentiate different attachments of the same volume.
+                        type: string
+                      nodeID:
+                        description: The node that this attachment is requesting
+                        type: string
+                      parameters:
+                        additionalProperties:
+                          type: string
+                        description: Optional additional parameter for this attachment
+                        type: object
+                      type:
+                        type: string
+                    type: object
+                  type: object
+                volume:
+                  description: The name of Longhorn volume of this VolumeAttachment
+                  type: string
+              required:
+                - volume
+              type: object
+            status:
+              description: VolumeAttachmentStatus defines the observed state of Longhorn VolumeAttachment
+              properties:
+                attachmentTicketStatuses:
+                  additionalProperties:
+                    properties:
+                      conditions:
+                        description: Record any error when trying to fulfill this attachment
+                        items:
+                          properties:
+                            lastProbeTime:
+                              description: Last time we probed the condition.
+                              type: string
+                            lastTransitionTime:
+                              description: Last time the condition transitioned from one status to another.
+                              type: string
+                            message:
+                              description: Human-readable message indicating details about last transition.
+                              type: string
+                            reason:
+                              description: Unique, one-word, CamelCase reason for the condition's last transition.
+                              type: string
+                            status:
+                              description: |-
+                                Status is the status of the condition.
+                                Can be True, False, Unknown.
+                              type: string
+                            type:
+                              description: Type is the type of the condition.
+                              type: string
+                          type: object
+                        nullable: true
+                        type: array
+                      generation:
+                        description: |-
+                          A sequence number representing a specific generation of the desired state.
+                          Populated by the system. Read-only.
+                        format: int64
+                        type: integer
+                      id:
+                        description: The unique ID of this attachment. Used to differentiate different attachments of the same volume.
+                        type: string
+                      satisfied:
+                        description: Indicate whether this attachment ticket has been satisfied
+                        type: boolean
+                    required:
+                      - conditions
+                      - satisfied
+                    type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    longhorn-manager: ""
+  name: volumes.longhorn.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: longhorn-conversion-webhook
+          namespace: longhorn-system
+          path: /v1/webhook/conversion
+          port: 9501
+      conversionReviewVersions:
+        - v1beta2
+        - v1beta1
+  group: longhorn.io
+  names:
+    kind: Volume
+    listKind: VolumeList
+    plural: volumes
+    shortNames:
+      - lhv
+    singular: volume
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns:
+        - description: The state of the volume
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The robustness of the volume
+          jsonPath: .status.robustness
+          name: Robustness
+          type: string
+        - description: The scheduled condition of the volume
+          jsonPath: .status.conditions['scheduled']['status']
+          name: Scheduled
+          type: string
+        - description: The size of the volume
+          jsonPath: .spec.size
+          name: Size
+          type: string
+        - description: The node that the volume is currently attaching to
+          jsonPath: .status.currentNodeID
+          name: Node
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Volume is where Longhorn stores volume object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              x-kubernetes-preserve-unknown-fields: true
+            status:
+              x-kubernetes-preserve-unknown-fields: true
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: The data engine of the volume
+          jsonPath: .spec.dataEngine
+          name: Data Engine
+          type: string
+        - description: The state of the volume
+          jsonPath: .status.state
+          name: State
+          type: string
+        - description: The robustness of the volume
+          jsonPath: .status.robustness
+          name: Robustness
+          type: string
+        - description: The scheduled condition of the volume
+          jsonPath: .status.conditions[?(@.type=='Schedulable')].status
+          name: Scheduled
+          type: string
+        - description: The size of the volume
+          jsonPath: .spec.size
+          name: Size
+          type: string
+        - description: The node that the volume is currently attaching to
+          jsonPath: .status.currentNodeID
+          name: Node
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta2
+      schema:
+        openAPIV3Schema:
+          description: Volume is where Longhorn stores volume object.
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: VolumeSpec defines the desired state of the Longhorn volume
+              properties:
+                Standby:
+                  type: boolean
+                accessMode:
+                  enum:
+                    - rwo
+                    - rwx
+                  type: string
+                backendStoreDriver:
+                  description: Deprecated:Replaced by field `dataEngine`.'
+                  type: string
+                backingImage:
+                  type: string
+                backupCompressionMethod:
+                  enum:
+                    - none
+                    - lz4
+                    - gzip
+                  type: string
+                backupTargetName:
+                  description: The backup target name that the volume will be backed up to or is synced.
+                  type: string
+                dataEngine:
+                  enum:
+                    - v1
+                    - v2
+                  type: string
+                dataLocality:
+                  enum:
+                    - disabled
+                    - best-effort
+                    - strict-local
+                  type: string
+                dataSource:
+                  type: string
+                disableFrontend:
+                  type: boolean
+                diskSelector:
+                  items:
+                    type: string
+                  type: array
+                encrypted:
+                  type: boolean
+                engineImage:
+                  description: "Deprecated: Replaced by field `image`."
+                  type: string
+                freezeFilesystemForSnapshot:
+                  description: Setting that freezes the filesystem on the root partition before a snapshot is created.
+                  enum:
+                    - ignored
+                    - enabled
+                    - disabled
+                  type: string
+                fromBackup:
+                  type: string
+                frontend:
+                  enum:
+                    - blockdev
+                    - iscsi
+                    - nvmf
+                    - ""
+                  type: string
+                image:
+                  type: string
+                lastAttachedBy:
+                  type: string
+                migratable:
+                  type: boolean
+                migrationNodeID:
+                  type: string
+                nodeID:
+                  type: string
+                nodeSelector:
+                  items:
+                    type: string
+                  type: array
+                numberOfReplicas:
+                  type: integer
+                replicaAutoBalance:
+                  enum:
+                    - ignored
+                    - disabled
+                    - least-effort
+                    - best-effort
+                  type: string
+                replicaDiskSoftAntiAffinity:
+                  description: Replica disk soft anti affinity of the volume. Set enabled to allow replicas to be scheduled in the same disk.
+                  enum:
+                    - ignored
+                    - enabled
+                    - disabled
+                  type: string
+                replicaSoftAntiAffinity:
+                  description: Replica soft anti affinity of the volume. Set enabled to allow replicas to be scheduled on the same node.
+                  enum:
+                    - ignored
+                    - enabled
+                    - disabled
+                  type: string
+                replicaZoneSoftAntiAffinity:
+                  description: Replica zone soft anti affinity of the volume. Set enabled to allow replicas to be scheduled in the same zone.
+                  enum:
+                    - ignored
+                    - enabled
+                    - disabled
+                  type: string
+                restoreVolumeRecurringJob:
+                  enum:
+                    - ignored
+                    - enabled
+                    - disabled
+                  type: string
+                revisionCounterDisabled:
+                  type: boolean
+                size:
+                  format: int64
+                  type: string
+                snapshotDataIntegrity:
+                  enum:
+                    - ignored
+                    - disabled
+                    - enabled
+                    - fast-check
+                  type: string
+                snapshotMaxCount:
+                  type: integer
+                snapshotMaxSize:
+                  format: int64
+                  type: string
+                staleReplicaTimeout:
+                  type: integer
+                unmapMarkSnapChainRemoved:
+                  enum:
+                    - ignored
+                    - disabled
+                    - enabled
+                  type: string
+              type: object
+            status:
+              description: VolumeStatus defines the observed state of the Longhorn volume
+              properties:
+                actualSize:
+                  format: int64
+                  type: integer
+                cloneStatus:
+                  properties:
+                    attemptCount:
+                      type: integer
+                    nextAllowedAttemptAt:
+                      type: string
+                    snapshot:
+                      type: string
+                    sourceVolume:
+                      type: string
+                    state:
+                      type: string
+                  type: object
+                conditions:
+                  items:
+                    properties:
+                      lastProbeTime:
+                        description: Last time we probed the condition.
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        type: string
+                      message:
+                        description: Human-readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: Unique, one-word, CamelCase reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: |-
+                          Status is the status of the condition.
+                          Can be True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type is the type of the condition.
+                        type: string
+                    type: object
+                  nullable: true
+                  type: array
+                currentImage:
+                  type: string
+                currentMigrationNodeID:
+                  description: the node that this volume is currently migrating to
+                  type: string
+                currentNodeID:
+                  type: string
+                expansionRequired:
+                  type: boolean
+                frontendDisabled:
+                  type: boolean
+                isStandby:
+                  type: boolean
+                kubernetesStatus:
+                  properties:
+                    lastPVCRefAt:
+                      type: string
+                    lastPodRefAt:
+                      type: string
+                    namespace:
+                      description: determine if PVC/Namespace is history or not
+                      type: string
+                    pvName:
+                      type: string
+                    pvStatus:
+                      type: string
+                    pvcName:
+                      type: string
+                    workloadsStatus:
+                      description: determine if Pod/Workload is history or not
+                      items:
+                        properties:
+                          podName:
+                            type: string
+                          podStatus:
+                            type: string
+                          workloadName:
+                            type: string
+                          workloadType:
+                            type: string
+                        type: object
+                      nullable: true
+                      type: array
+                  type: object
+                lastBackup:
+                  type: string
+                lastBackupAt:
+                  type: string
+                lastDegradedAt:
+                  type: string
+                ownerID:
+                  type: string
+                pendingNodeID:
+                  description: Deprecated.
+                  type: string
+                remountRequestedAt:
+                  type: string
+                restoreInitiated:
+                  type: boolean
+                restoreRequired:
+                  type: boolean
+                robustness:
+                  type: string
+                shareEndpoint:
+                  type: string
+                shareState:
+                  type: string
+                state:
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/kubernetes/longhorn/base/daemonset.yaml
+++ b/kubernetes/longhorn/base/daemonset.yaml
@@ -1,0 +1,127 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-manager
+  name: longhorn-manager
+  namespace: longhorn-system
+spec:
+  selector:
+    matchLabels:
+      app: longhorn-manager
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.8.1
+        app: longhorn-manager
+    spec:
+      containers:
+        - name: longhorn-manager
+          image: longhornio/longhorn-manager:v1.8.1
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            privileged: true
+          command:
+            - longhorn-manager
+            - -d
+            - daemon
+            - --engine-image
+            - longhornio/longhorn-engine:v1.8.1
+            - --instance-manager-image
+            - longhornio/longhorn-instance-manager:v1.8.1
+            - --share-manager-image
+            - longhornio/longhorn-share-manager:v1.8.1
+            - --backing-image-manager-image
+            - longhornio/backing-image-manager:v1.8.1
+            - --support-bundle-manager-image
+            - longhornio/support-bundle-kit:v0.0.52
+            - --manager-image
+            - longhornio/longhorn-manager:v1.8.1
+            - --service-account
+            - longhorn-service-account
+            - --upgrade-version-check
+          ports:
+            - containerPort: 9500
+              name: manager
+            - containerPort: 9501
+              name: conversion-wh
+            - containerPort: 9502
+              name: admission-wh
+            - containerPort: 9503
+              name: recov-backend
+          readinessProbe:
+            httpGet:
+              path: /v1/healthz
+              port: 9501
+              scheme: HTTPS
+          volumeMounts:
+            - name: boot
+              mountPath: /host/boot/
+              readOnly: true
+            - name: dev
+              mountPath: /host/dev/
+            - name: proc
+              mountPath: /host/proc/
+              readOnly: true
+            - name: etc
+              mountPath: /host/etc/
+              readOnly: true
+            - name: longhorn
+              mountPath: /var/lib/longhorn/
+              mountPropagation: Bidirectional
+            - name: longhorn-grpc-tls
+              mountPath: /tls-files/
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+        - name: pre-pull-share-manager-image
+          imagePullPolicy: IfNotPresent
+          image: longhornio/longhorn-share-manager:v1.8.1
+          command:
+            - sh
+            - -c
+            - echo share-manager image pulled && sleep infinity
+      volumes:
+        - name: boot
+          hostPath:
+            path: /boot/
+        - name: dev
+          hostPath:
+            path: /dev/
+        - name: proc
+          hostPath:
+            path: /proc/
+        - name: etc
+          hostPath:
+            path: /etc/
+        - name: longhorn
+          hostPath:
+            path: /var/lib/longhorn/
+        - name: longhorn-grpc-tls
+          secret:
+            secretName: longhorn-grpc-tls
+            optional: true
+      priorityClassName: longhorn-critical
+      serviceAccountName: longhorn-service-account
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 100%

--- a/kubernetes/longhorn/base/deployment-longhorn-driver-deployer.yaml
+++ b/kubernetes/longhorn/base/deployment-longhorn-driver-deployer.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: longhorn-driver-deployer
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: longhorn-driver-deployer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.8.1
+        app: longhorn-driver-deployer
+    spec:
+      initContainers:
+        - name: wait-longhorn-manager
+          image: longhornio/longhorn-manager:v1.8.1
+          command:
+            - sh
+            - -c
+            - while [ $(curl -m 1 -s -o /dev/null -w "%{http_code}" http://longhorn-backend:9500/v1) != "200" ]; do echo waiting; sleep 2; done
+      containers:
+        - name: longhorn-driver-deployer
+          image: longhornio/longhorn-manager:v1.8.1
+          imagePullPolicy: IfNotPresent
+          command:
+            - longhorn-manager
+            - -d
+            - deploy-driver
+            - --manager-image
+            - longhornio/longhorn-manager:v1.8.1
+            - --manager-url
+            - http://longhorn-backend:9500/v1
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: SERVICE_ACCOUNT
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.serviceAccountName
+            - name: CSI_ATTACHER_IMAGE
+              value: longhornio/csi-attacher:v4.8.1
+            - name: CSI_PROVISIONER_IMAGE
+              value: longhornio/csi-provisioner:v5.2.0
+            - name: CSI_NODE_DRIVER_REGISTRAR_IMAGE
+              value: longhornio/csi-node-driver-registrar:v2.13.0
+            - name: CSI_RESIZER_IMAGE
+              value: longhornio/csi-resizer:v1.13.2
+            - name: CSI_SNAPSHOTTER_IMAGE
+              value: longhornio/csi-snapshotter:v8.2.0
+            - name: CSI_LIVENESS_PROBE_IMAGE
+              value: longhornio/livenessprobe:v2.15.0
+      priorityClassName: longhorn-critical
+      serviceAccountName: longhorn-service-account
+      securityContext:
+        runAsUser: 0

--- a/kubernetes/longhorn/base/deployment-longhorn-ui.yaml
+++ b/kubernetes/longhorn/base/deployment-longhorn-ui.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-ui
+  name: longhorn-ui
+  namespace: longhorn-system
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: longhorn-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: longhorn
+        app.kubernetes.io/instance: longhorn
+        app.kubernetes.io/version: v1.8.1
+        app: longhorn-ui
+    spec:
+      serviceAccountName: longhorn-ui-service-account
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - longhorn-ui
+                topologyKey: kubernetes.io/hostname
+      containers:
+        - name: longhorn-ui
+          image: longhornio/longhorn-ui:v1.8.1
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx/
+            - name: nginx-config
+              mountPath: /var/config/nginx/
+            - name: var-run
+              mountPath: /var/run/
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: LONGHORN_MANAGER_IP
+              value: http://longhorn-backend:9500
+            - name: LONGHORN_UI_PORT
+              value: "8000"
+      volumes:
+        - emptyDir: {}
+          name: nginx-cache
+        - emptyDir: {}
+          name: nginx-config
+        - emptyDir: {}
+          name: var-run
+      priorityClassName: longhorn-critical

--- a/kubernetes/longhorn/base/kustomization.yaml
+++ b/kubernetes/longhorn/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - clusterrole.yaml
+  - clusterrolebinding.yaml
+  - configmap.yaml
+  - customresourcedefinition.yaml
+  - daemonset.yaml
+  - deployment-longhorn-driver-deployer.yaml
+  - deployment-longhorn-ui.yaml
+  - namespace.yaml
+  - priorityclass.yaml
+  - service.yaml
+  - serviceaccount.yaml

--- a/kubernetes/longhorn/base/namespace.yaml
+++ b/kubernetes/longhorn/base/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system

--- a/kubernetes/longhorn/base/priorityclass.yaml
+++ b/kubernetes/longhorn/base/priorityclass.yaml
@@ -1,0 +1,12 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: longhorn-critical
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+description: Ensure Longhorn pods have the highest priority to prevent any unexpected eviction by the Kubernetes scheduler under node pressure
+globalDefault: false
+preemptionPolicy: PreemptLowerPriority
+value: 1000000000

--- a/kubernetes/longhorn/base/service.yaml
+++ b/kubernetes/longhorn/base/service.yaml
@@ -1,0 +1,95 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-manager
+  name: longhorn-backend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: longhorn-manager
+  ports:
+    - name: manager
+      port: 9500
+      targetPort: manager
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-ui
+  name: longhorn-frontend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    app: longhorn-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      nodePort: null
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-conversion-webhook
+  name: longhorn-conversion-webhook
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/conversion-webhook: longhorn-conversion-webhook
+  ports:
+    - name: conversion-webhook
+      port: 9501
+      targetPort: conversion-wh
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-admission-webhook
+  name: longhorn-admission-webhook
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/admission-webhook: longhorn-admission-webhook
+  ports:
+    - name: admission-webhook
+      port: 9502
+      targetPort: admission-wh
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+    app: longhorn-recovery-backend
+  name: longhorn-recovery-backend
+  namespace: longhorn-system
+spec:
+  type: ClusterIP
+  selector:
+    longhorn.io/recovery-backend: longhorn-recovery-backend
+  ports:
+    - name: recovery-backend
+      port: 9503
+      targetPort: recov-backend

--- a/kubernetes/longhorn/base/serviceaccount.yaml
+++ b/kubernetes/longhorn/base/serviceaccount.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-service-account
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-ui-service-account
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: longhorn-support-bundle
+  namespace: longhorn-system
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/instance: longhorn
+    app.kubernetes.io/version: v1.8.1

--- a/kubernetes/longhorn/overlays/pi-cluster/ingress.yaml
+++ b/kubernetes/longhorn/overlays/pi-cluster/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: longhorn-ingress
+  namespace: longhorn-system
+  annotations:
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/ssl-redirect: 'false'
+    nginx.ingress.kubernetes.io/auth-secret: basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required'
+    # custom max body size for file uploading like backing image uploading
+    nginx.ingress.kubernetes.io/proxy-body-size: 10000m
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: longhorn.homelab.jenniferpweir.com
+    http:
+      paths:
+      - pathType: Prefix
+        path: "/"
+        backend:
+          service:
+            name: longhorn-frontend
+            port:
+              number: 80

--- a/kubernetes/longhorn/overlays/pi-cluster/kustomization.yaml
+++ b/kubernetes/longhorn/overlays/pi-cluster/kustomization.yaml
@@ -1,0 +1,15 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ../../base
+  - ingress.yaml
+patches:
+  - target:
+      group: ""
+      kind: Service
+      name: longhorn-frontend
+      namespace: longhorn-system
+    patch: |-
+      - op: replace
+        path: /spec/type
+        value: LoadBalancer

--- a/scripts/create-manifests.sh
+++ b/scripts/create-manifests.sh
@@ -8,10 +8,10 @@ shopt -s failglob
 mkdir -p base
 pushd base > /dev/null || exit 1
 
-MANIFEST-URL="<CHANGE-ME>"
+MANIFESTURL="<CHANGE-ME>"
 
 # Download manifests and separate into separate files
-curl -sL "${MANIFEST_URL}" | \
+curl -sL "${MANIFESTURL}" | \
     yq --no-colors --prettyPrint '... comments=""' | \
     kubectl-slice -o . --template "{{ .kind | lower }}.yaml"
 


### PR DESCRIPTION
# Description of changes made
- Installs Longhorn as storage solution in k8s pi cluster
- Exposes longhorn ui with nginx ingress controller using service `type: LoadBalancer`
