### PR TITLE
feat(prometheus): testing pvc creation

### DIFF
--- a/docs/selinux.md
+++ b/docs/selinux.md
@@ -17,3 +17,10 @@ semodule -X 300 -i my-rpclibvirtd.pp
 # as root, set haproxy_connect_any to true and make it persistent across reboots
 setsebool -P haproxy_connect_any=1
 ```
+
+## allow rpc-virtqemud access on blk_file
+
+```bash
+ausearch -c 'rpc-virtqemud' --raw | audit2allow -M my-rpcvirtqemud
+semodule -X 300 -i my-rpcvirtqemud.pp
+```

--- a/kubernetes/prometheus/base/deployment.yaml
+++ b/kubernetes/prometheus/base/deployment.yaml
@@ -21,8 +21,13 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/prometheus
+            - name: prometheus-storage
+              mountPath: /prometheus
       volumes:
         - name: config-volume
           configMap:
             name: prometheus-server-conf
             defaultMode: 420
+        - name: prometheus-storage
+          persistentVolumeClaim:
+            claimName: prometheus-pvc

--- a/kubernetes/prometheus/overlays/okd/ingress.yaml
+++ b/kubernetes/prometheus/overlays/okd/ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus-ingress
+  namespace: prometheus
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  ingressClassName: openshift-default
+  rules:
+  - host: prometheus.apps.okd.jenniferpweir.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service: 
+            name: prometheus-service
+            port:
+              number: 9090

--- a/kubernetes/prometheus/overlays/okd/kustomization.yaml
+++ b/kubernetes/prometheus/overlays/okd/kustomization.yaml
@@ -1,0 +1,26 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+  - ../../base
+  - pvc.yaml
+  - ingress.yaml
+patches:
+  - target: 
+      kind: Deployment
+      name: prometheus
+    patch: |-
+      - op: add
+        path: /spec/template
+        value: 
+          spec:
+            affinity:
+              nodeAffinity:
+                requiredDuringSchedulingIgnoredDuringExecution:
+                  nodeSelectorTerms:
+                    - matchExpressions:
+                        - key: node-role.kubernetes.io/infra
+                          operator: Exists
+            tolerations:
+              - key: node-role.kubernetes.io/infra
+                operator: Exists
+                effect: NoSchedule

--- a/kubernetes/prometheus/overlays/okd/pvc.yaml
+++ b/kubernetes/prometheus/overlays/okd/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-pvc
+  namespace: prometheus
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: rook-ceph-block-replicated
+  resources:
+    requests:
+      storage: 8Gi

--- a/kubernetes/rook-ceph/README.md
+++ b/kubernetes/rook-ceph/README.md
@@ -1,0 +1,11 @@
+# Ceph notes
+
+- `ceph osd pool application enable .mgr mgr`
+- If storage device backing osd is up but ceph is reporting that osd as down, bouncing the rook-ceph-osd pod for that osd will make ceph recognize it is back up
+- Use ceph tools pod to check health and clear warnings
+  - `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph status`
+  - `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph osd tree`
+  - `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph crash ls`
+  - `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph crash info <ID>`
+  - `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph crash archive <ID>`
+  - `kubectl exec -it -n rook-ceph deploy/rook-ceph-tools -- ceph df`

--- a/kubernetes/rook-ceph/base/kustomization.yaml
+++ b/kubernetes/rook-ceph/base/kustomization.yaml
@@ -2,3 +2,5 @@ kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 resources:
   - cluster.yaml
+  - storageclass-replicated.yaml
+  - storageclass-single.yaml

--- a/kubernetes/rook-ceph/base/storageclass-replicated.yaml
+++ b/kubernetes/rook-ceph/base/storageclass-replicated.yaml
@@ -1,0 +1,94 @@
+# https://github.com/rook/rook/blob/release-1.12/deploy/examples/csi/rbd/storageclass.yaml
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool-replicated
+  namespace: rook-ceph # namespace:cluster
+spec:
+  failureDomain: host
+  replicated:
+    size: 3
+    # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+    # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+    requireSafeReplicaSize: true
+    # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+    # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+    #targetSizeRatio: .5
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block-replicated
+# Change "rook-ceph" provisioner prefix to match the operator namespace if needed
+provisioner: rook-ceph.rbd.csi.ceph.com
+parameters:
+  # clusterID is the namespace where the rook cluster is running
+  # If you change this namespace, also change the namespace below where the secret namespaces are defined
+  clusterID: rook-ceph # namespace:cluster
+
+  # If you want to use erasure coded pool with RBD, you need to create
+  # two pools. one erasure coded and one replicated.
+  # You need to specify the replicated pool here in the `pool` parameter, it is
+  # used for the metadata of the images.
+  # The erasure coded pool must be set as the `dataPool` parameter below.
+  #dataPool: ec-data-pool
+  pool: replicapool-replicated
+
+  # (optional) mapOptions is a comma-separated list of map options.
+  # For krbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+  # For nbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+  # mapOptions: lock_on_read,queue_depth=1024
+
+  # (optional) unmapOptions is a comma-separated list of unmap options.
+  # For krbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd/#kernel-rbd-krbd-options
+  # For nbd options refer
+  # https://docs.ceph.com/docs/master/man/8/rbd-nbd/#options
+  # unmapOptions: force
+
+   # (optional) Set it to true to encrypt each volume with encryption keys
+   # from a key management system (KMS)
+   # encrypted: "true"
+
+   # (optional) Use external key management system (KMS) for encryption key by
+   # specifying a unique ID matching a KMS ConfigMap. The ID is only used for
+   # correlation to configmap entry.
+   # encryptionKMSID: <kms-config-id>
+
+  # RBD image format. Defaults to "2".
+  imageFormat: "2"
+
+  # RBD image features
+  # Available for imageFormat: "2". Older releases of CSI RBD
+  # support only the `layering` feature. The Linux kernel (KRBD) supports the
+  # full complement of features as of 5.4
+  # `layering` alone corresponds to Ceph's bitfield value of "2" ;
+  # `layering` + `fast-diff` + `object-map` + `deep-flatten` + `exclusive-lock` together
+  # correspond to Ceph's OR'd bitfield value of "63". Here we use
+  # a symbolic, comma-separated format:
+  # For 5.4 or later kernels:
+  #imageFeatures: layering,fast-diff,object-map,deep-flatten,exclusive-lock
+  # For 5.3 or earlier kernels:
+  imageFeatures: layering
+
+  # The secrets contain Ceph admin credentials. These are generated automatically by the operator
+  # in the same namespace as the cluster.
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
+  # Specify the filesystem type of the volume. If not specified, csi-provisioner
+  # will set default as `ext4`. Note that `xfs` is not recommended due to potential deadlock
+  # in hyperconverged settings where the volume is mounted on the same node as the osds.
+  csi.storage.k8s.io/fstype: ext4
+# uncomment the following to use rbd-nbd as mounter on supported nodes
+# **IMPORTANT**: CephCSI v3.4.0 onwards a volume healer functionality is added to reattach
+# the PVC to application pod if nodeplugin pod restart.
+# Its still in Alpha support. Therefore, this option is not recommended for production use.
+#mounter: rbd-nbd
+allowVolumeExpansion: true
+reclaimPolicy: Delete

--- a/kubernetes/rook-ceph/base/storageclass-single.yaml
+++ b/kubernetes/rook-ceph/base/storageclass-single.yaml
@@ -1,0 +1,57 @@
+# https://github.com/rook/rook/blob/release-1.12/deploy/examples/csi/rbd/storageclass-test.yaml
+apiVersion: ceph.rook.io/v1
+kind: CephBlockPool
+metadata:
+  name: replicapool-single
+  namespace: rook-ceph # namespace:cluster
+spec:
+  failureDomain: osd
+  replicated:
+    size: 1
+    # Disallow setting pool with replica 1, this could lead to data loss without recovery.
+    # Make sure you're *ABSOLUTELY CERTAIN* that is what you want
+    requireSafeReplicaSize: false
+    # gives a hint (%) to Ceph in terms of expected consumption of the total cluster capacity of a given pool
+    # for more info: https://docs.ceph.com/docs/master/rados/operations/placement-groups/#specifying-expected-pool-size
+    #targetSizeRatio: .5
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: rook-ceph-block-single
+# Change "rook-ceph" provisioner prefix to match the operator namespace if needed
+provisioner: rook-ceph.rbd.csi.ceph.com # driver:namespace:operator
+parameters:
+  # clusterID is the namespace where the rook cluster is running
+  # If you change this namespace, also change the namespace below where the secret namespaces are defined
+  clusterID: rook-ceph # namespace:cluster
+
+  # If you want to use erasure coded pool with RBD, you need to create
+  # two pools. one erasure coded and one replicated.
+  # You need to specify the replicated pool here in the `pool` parameter, it is
+  # used for the metadata of the images.
+  # The erasure coded pool must be set as the `dataPool` parameter below.
+  #dataPool: ec-data-pool
+  pool: replicapool-single
+
+  # RBD image format. Defaults to "2".
+  imageFormat: "2"
+
+  # RBD image features. Available for imageFormat: "2". CSI RBD currently supports only `layering` feature.
+  imageFeatures: layering
+
+  # The secrets contain Ceph admin credentials. These are generated automatically by the operator
+  # in the same namespace as the cluster.
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph # namespace:cluster
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph # namespace:cluster
+  # Specify the filesystem type of the volume. If not specified, csi-provisioner
+  # will set default as `ext4`.
+  csi.storage.k8s.io/fstype: ext4
+# uncomment the following to use rbd-nbd as mounter on supported nodes
+#mounter: rbd-nbd
+allowVolumeExpansion: true
+reclaimPolicy: Delete


### PR DESCRIPTION
## Description
- Includes storageclasses that were not included in #65 
- Demonstrates successfully bound pvc to prometheus as a test
- Some notes included
```
NAME             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                 VOLUMEATTRIBUTESCLASS   AGE
prometheus-pvc   Bound    pvc-181f912a-937d-48d8-9c30-227e1f648db9   8Gi        RWO            rook-ceph-block-replicated   <unset>                 2d7h

NAME                                READY   STATUS    RESTARTS   AGE
prometheus-server-c866557c9-gbdp4   1/1     Running   0          2d7h

kubectl get volumeattachments | grep pvc-181f912a-937d-48d8-9c30-227e1f648db9
csi-df0a88b5d5d7ffda9daccda0d20b7679fa935144b4147adaa6b01410e545d924   rook-ceph.rbd.csi.ceph.com   pvc-181f912a-937d-48d8-9c30-227e1f648db9   worker-2.okd.jenniferpweir.com   true       2d7h

bash-5.1$ ceph osd pool ls
.mgr
replicapool-single
replicapool-replicated
bash-5.1$ rbd ls replicapool-replicated
csi-vol-1c4aa4f7-eedb-48f6-9286-5d7222b4451e
bash-5.1$ rbd info -p replicapool-replicated csi-vol-1c4aa4f7-eedb-48f6-9286-5d7222b4451e
rbd image 'csi-vol-1c4aa4f7-eedb-48f6-9286-5d7222b4451e':
	size 8 GiB in 2048 objects
	order 22 (4 MiB objects)
	snapshot_count: 0
	id: a8383a65c9a6
	block_name_prefix: rbd_data.a8383a65c9a6
	format: 2
	features: layering
	op_features:
	flags:
	create_timestamp: Sat Apr 26 20:31:09 2025
	access_timestamp: Sat Apr 26 20:31:09 2025
	modify_timestamp: Sat Apr 26 20:31:09 2025
bash-5.1$ ceph df
--- RAW STORAGE ---
CLASS     SIZE    AVAIL     USED  RAW USED  %RAW USED
hdd    5.5 TiB  5.5 TiB  3.9 GiB   3.9 GiB       0.07
TOTAL  5.5 TiB  5.5 TiB  3.9 GiB   3.9 GiB       0.07

--- POOLS ---
POOL                    ID  PGS   STORED  OBJECTS     USED  %USED  MAX AVAIL
.mgr                     1    1  449 KiB        2  1.3 MiB      0    1.7 TiB
replicapool-single       2   32     19 B        2    4 KiB      0    5.2 TiB
replicapool-replicated   3   32  147 MiB      103  440 MiB      0    1.7 TiB
bash-5.1$ ceph osd pool stats
pool .mgr id 1
  nothing is going on

pool replicapool-single id 2
  nothing is going on

pool replicapool-replicated id 3
  client io 1023 B/s wr, 0 op/s rd, 0 op/s wr
```