### PR TITLE
feat(custom-ingress): endpointPublishingStrategy LoadBalancerService

### DIFF
--- a/kubernetes/metallb/base/L2advertisement.yaml
+++ b/kubernetes/metallb/base/L2advertisement.yaml
@@ -1,0 +1,5 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: lb-advertisement
+  namespace: metallb-system

--- a/kubernetes/metallb/base/kustomization.yaml
+++ b/kubernetes/metallb/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - customresourcedefinition.yaml
   - daemonset.yaml
   - deployment-controller.yaml
+  - L2advertisement.yaml
   - namespace.yaml
   - role.yaml
   - rolebinding.yaml

--- a/kubernetes/metallb/overlays/okd/ip-addr-pool.yaml
+++ b/kubernetes/metallb/overlays/okd/ip-addr-pool.yaml
@@ -5,4 +5,4 @@ metadata:
   namespace: metallb-system
 spec:
   addresses:
-  - 192.168.0.235-192.168.0.255
+  - 192.168.0.225-192.168.0.234

--- a/kubernetes/metallb/overlays/okd/kustomization.yaml
+++ b/kubernetes/metallb/overlays/okd/kustomization.yaml
@@ -1,0 +1,46 @@
+kind: Kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: metallb-system
+resources:
+  - ../../base
+  - ip-addr-pool.yaml
+  - rolebinding.yaml
+patches:
+  - target: 
+      kind: Deployment
+      name: controller
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value: 
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+      - op: add
+        path: /spec/template/spec/tolerations
+        value:
+          - key: node-role.kubernetes.io/infra
+            operator: Exists
+            effect: NoSchedule
+  - target: 
+      kind: DaemonSet
+      name: speaker
+    patch: |-
+      - op: add
+        path: /spec/template/spec/affinity
+        value: 
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: node-role.kubernetes.io/infra
+                      operator: Exists
+      - op: add
+        path: /spec/template/spec/tolerations
+        value:
+          - key: node-role.kubernetes.io/infra
+            operator: Exists
+            effect: NoSchedule

--- a/kubernetes/metallb/overlays/okd/rolebinding.yaml
+++ b/kubernetes/metallb/overlays/okd/rolebinding.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-anyuid-for-metallb-controller
+  namespace: metallb-system
+subjects:
+  - kind: ServiceAccount
+    name: controller
+    namespace: metallb-system
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-metallb-speaker-to-use-privileged-scc
+  namespace: metallb-system
+subjects:
+  - kind: ServiceAccount
+    name: speaker
+    namespace: metallb-system
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io

--- a/okd/openshift-ingress/custom-ingress-controller.yaml
+++ b/okd/openshift-ingress/custom-ingress-controller.yaml
@@ -1,0 +1,20 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: custom
+  namespace: openshift-ingress-operator
+spec:
+  clientTLS:
+    clientCA:
+      name: ""
+    clientCertificatePolicy: ""
+  httpEmptyRequestsPolicy: Respond
+  httpErrorCodePages:
+    name: ""
+  idleConnectionTerminationPolicy: Deferred
+  replicas: 2
+  tuningOptions:
+    reloadInterval: 0s
+  endpointPublishingStrategy:
+    type: LoadBalancerService
+  domain: custom.okd.jenniferpweir.com

--- a/okd/openshift-ingress/default-ingress-controller.yaml
+++ b/okd/openshift-ingress/default-ingress-controller.yaml
@@ -1,0 +1,17 @@
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  clientTLS:
+    clientCA:
+      name: ""
+    clientCertificatePolicy: ""
+  httpEmptyRequestsPolicy: Respond
+  httpErrorCodePages:
+    name: ""
+  idleConnectionTerminationPolicy: Deferred
+  replicas: 2
+  tuningOptions:
+    reloadInterval: 0s


### PR DESCRIPTION
# Description of changes made
- Creates custom ingresscontroller using endpointPublishingStrategy LoadBalancerService
- Exposes service `type: LoadBalancer` using metallb
