### PR TITLE
fix(argocd-operator): cluster scoped subscription

### DIFF
--- a/kubernetes/argocd-operator/subscription.yaml
+++ b/kubernetes/argocd-operator/subscription.yaml
@@ -11,6 +11,9 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: argocd-operator.v0.13.0
   config:
+    env:
+      - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
+        value: argocd # https://access.redhat.com/solutions/7026814
     nodeSelector:
       node-role.kubernetes.io/infra: ""
     tolerations:


### PR DESCRIPTION
# Description of changes made
- `ARGOCD_CLUSTER_CONFIG_NAMESPACES` env config creates cluster scoped argocd instance

## Does this PR address or close any existing issues?
- deploy ArgoCD instance that can manage multiple namespaces
