### PR TITLE
fix: remove individual application references

### DIFF
--- a/manifests/platform/argocd/overlays/okd/kustomization.yaml
+++ b/manifests/platform/argocd/overlays/okd/kustomization.yaml
@@ -3,9 +3,3 @@ kind: Kustomization
 resources:
   - ../../operator/base
   - ../../operator/components
-  - ../../operator/applications/argocd-operator
-  - ../../operator/applications/cluster-version
-  - ../../operator/applications/console-config
-  - ../../operator/applications/external-secrets-operator
-  - ../../operator/applications/grafana-operator
-  - ../../operator/applications/operatorhub


### PR DESCRIPTION
# Description of changes made
Components now includes applications.yaml (applications argo app) which syncs all other argo apps. Individual application references not needed
