### PR TITLE
fix(certificate): use openshift-ingress ns

### DIFF
--- a/manifests/platform/openshift-ingress/operator/certificate.yaml
+++ b/manifests/platform/openshift-ingress/operator/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: console-cert
-  namespace: openshift-ingress-operator
+  namespace: openshift-ingress
 spec:
   secretName: console-tls
   privateKey:


### PR DESCRIPTION
# Description of changes made
- use openshift-ingress, not openshift-ingress-operator ns since the ingress pods need access to the cert secret
