### PR TITLE
feat(k8s): coreos installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 /secrets
 .kube/*
+.env
+.secrets.env
+*.ign
 
 # Terraform
 .terraform/

--- a/installation/k8s/coreos-lab/.secrets.env.example
+++ b/installation/k8s/coreos-lab/.secrets.env.example
@@ -1,0 +1,2 @@
+SSH_PUBLIC_KEY='ssh-rsa AAAA...'
+PASSWORD_HASH='$y$j9T$...'

--- a/installation/k8s/coreos-lab/k8s1.bu
+++ b/installation/k8s/coreos-lab/k8s1.bu
@@ -1,0 +1,165 @@
+variant: fcos
+version: 1.7.0
+
+ignition:
+  config:
+    merge: []
+  timeouts:
+    http_response_headers: 10
+    http_total: 0
+  security:
+    tls:
+      certificate_authorities: []
+
+storage:
+  disks:
+    - device: /dev/disk/by-id/DATA_DISK_REPLACE_ME
+      wipe_table: true
+      partitions:
+        - number: 1
+          label: VARLIB
+          size_mib: 153600
+          start_mib: 0
+          wipe_partition_entry: true
+        - number: 2
+          label: CEPH
+          size_mib: 0
+          start_mib: 0
+          wipe_partition_entry: true
+  filesystems:
+    - device: /dev/disk/by-partlabel/VARLIB
+      format: ext4
+      label: VARLIB
+      path: /var/lib
+      options:
+        - -T
+        - small
+      wipe_filesystem: true
+      with_mount_unit: true
+  files:
+    - path: /etc/modules-load.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          overlay
+          br_netfilter
+    - path: /etc/sysctl.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+    - path: /etc/kubernetes/kubelet.yaml
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          resolvConf: /run/systemd/resolve/resolv.conf
+          rotateCertificates: true
+  directories: []
+  links: []
+
+systemd:
+  units:
+    - name: restorecon-var-lib.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Relabel /var/lib for SELinux
+        Requires=var-lib.mount
+        After=var-lib.mount
+        Before=crio.service kubelet.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/restorecon -R /var/lib
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: sys-fs-bpf.mount
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Mount BPF Filesystem for Cilium eBPF
+        DefaultDependencies=no
+        Before=local-fs.target
+        [Mount]
+        What=bpffs
+        Where=/sys/fs/bpf
+        Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime
+        [Install]
+        WantedBy=local-fs.target
+
+    - name: crio.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CRI-O Container Runtime
+        Documentation=https://github.com/cri-o/cri-o
+        Requires=var-lib.mount
+        After=network.target local-fs.target var-lib.mount
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/crio
+        ExecReload=/bin/kill -HUP $MAINPID
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io
+        Requires=crio.service sys-fs-bpf.mount
+        After=crio.service sys-fs-bpf.mount
+        [Service]
+        ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubelet.conf --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - {{ SSH_PUBLIC_KEY }}
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}
+      groups:
+        - sudo
+      shell: /bin/bash
+      no_create_home: false
+  groups: []
+
+kernel_arguments:
+  should_exist: []
+  should_not_exist: []
+
+boot_device:
+  layout: x86_64
+  luks:
+    device: /dev/disk/by-id/REPLACE_ME
+    tpm2: true
+    threshold: 1
+    discard: false
+
+grub:
+  users:
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}

--- a/installation/k8s/coreos-lab/k8s1.bu
+++ b/installation/k8s/coreos-lab/k8s1.bu
@@ -1,3 +1,4 @@
+# boot device: /dev/disk/by-id/BOOT_DISK_REPLACE_ME
 variant: fcos
 version: 1.7.0
 
@@ -153,11 +154,6 @@ kernel_arguments:
 
 boot_device:
   layout: x86_64
-  luks:
-    device: /dev/disk/by-id/REPLACE_ME
-    tpm2: true
-    threshold: 1
-    discard: false
 
 grub:
   users:

--- a/installation/k8s/coreos-lab/k8s2.bu
+++ b/installation/k8s/coreos-lab/k8s2.bu
@@ -1,0 +1,165 @@
+variant: fcos
+version: 1.7.0
+
+ignition:
+  config:
+    merge: []
+  timeouts:
+    http_response_headers: 10
+    http_total: 0
+  security:
+    tls:
+      certificate_authorities: []
+
+storage:
+  disks:
+    - device: /dev/disk/by-id/DATA_DISK_REPLACE_ME
+      wipe_table: true
+      partitions:
+        - number: 1
+          label: VARLIB
+          size_mib: 153600
+          start_mib: 0
+          wipe_partition_entry: true
+        - number: 2
+          label: CEPH
+          size_mib: 0
+          start_mib: 0
+          wipe_partition_entry: true
+  filesystems:
+    - device: /dev/disk/by-partlabel/VARLIB
+      format: ext4
+      label: VARLIB
+      path: /var/lib
+      options:
+        - -T
+        - small
+      wipe_filesystem: true
+      with_mount_unit: true
+  files:
+    - path: /etc/modules-load.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          overlay
+          br_netfilter
+    - path: /etc/sysctl.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+    - path: /etc/kubernetes/kubelet.yaml
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          resolvConf: /run/systemd/resolve/resolv.conf
+          rotateCertificates: true
+  directories: []
+  links: []
+
+systemd:
+  units:
+    - name: restorecon-var-lib.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Relabel /var/lib for SELinux
+        Requires=var-lib.mount
+        After=var-lib.mount
+        Before=crio.service kubelet.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/restorecon -R /var/lib
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: sys-fs-bpf.mount
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Mount BPF Filesystem for Cilium eBPF
+        DefaultDependencies=no
+        Before=local-fs.target
+        [Mount]
+        What=bpffs
+        Where=/sys/fs/bpf
+        Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime
+        [Install]
+        WantedBy=local-fs.target
+
+    - name: crio.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CRI-O Container Runtime
+        Documentation=https://github.com/cri-o/cri-o
+        Requires=var-lib.mount
+        After=network.target local-fs.target var-lib.mount
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/crio
+        ExecReload=/bin/kill -HUP $MAINPID
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io
+        Requires=crio.service sys-fs-bpf.mount
+        After=crio.service sys-fs-bpf.mount
+        [Service]
+        ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubelet.conf --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - {{ SSH_PUBLIC_KEY }}
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}
+      groups:
+        - sudo
+      shell: /bin/bash
+      no_create_home: false
+  groups: []
+
+kernel_arguments:
+  should_exist: []
+  should_not_exist: []
+
+boot_device:
+  layout: x86_64
+  luks:
+    device: /dev/disk/by-id/REPLACE_ME
+    tpm2: true
+    threshold: 1
+    discard: false
+
+grub:
+  users:
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}

--- a/installation/k8s/coreos-lab/k8s2.bu
+++ b/installation/k8s/coreos-lab/k8s2.bu
@@ -1,3 +1,4 @@
+# boot device: /dev/disk/by-id/BOOT_DISK_REPLACE_ME
 variant: fcos
 version: 1.7.0
 
@@ -153,11 +154,6 @@ kernel_arguments:
 
 boot_device:
   layout: x86_64
-  luks:
-    device: /dev/disk/by-id/REPLACE_ME
-    tpm2: true
-    threshold: 1
-    discard: false
 
 grub:
   users:

--- a/installation/k8s/coreos-lab/k8s3.bu
+++ b/installation/k8s/coreos-lab/k8s3.bu
@@ -1,0 +1,165 @@
+variant: fcos
+version: 1.7.0
+
+ignition:
+  config:
+    merge: []
+  timeouts:
+    http_response_headers: 10
+    http_total: 0
+  security:
+    tls:
+      certificate_authorities: []
+
+storage:
+  disks:
+    - device: /dev/disk/by-id/DATA_DISK_REPLACE_ME
+      wipe_table: true
+      partitions:
+        - number: 1
+          label: VARLIB
+          size_mib: 153600
+          start_mib: 0
+          wipe_partition_entry: true
+        - number: 2
+          label: CEPH
+          size_mib: 0
+          start_mib: 0
+          wipe_partition_entry: true
+  filesystems:
+    - device: /dev/disk/by-partlabel/VARLIB
+      format: ext4
+      label: VARLIB
+      path: /var/lib
+      options:
+        - -T
+        - small
+      wipe_filesystem: true
+      with_mount_unit: true
+  files:
+    - path: /etc/modules-load.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          overlay
+          br_netfilter
+    - path: /etc/sysctl.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+    - path: /etc/kubernetes/kubelet.yaml
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          resolvConf: /run/systemd/resolve/resolv.conf
+          rotateCertificates: true
+  directories: []
+  links: []
+
+systemd:
+  units:
+    - name: restorecon-var-lib.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Relabel /var/lib for SELinux
+        Requires=var-lib.mount
+        After=var-lib.mount
+        Before=crio.service kubelet.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/restorecon -R /var/lib
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: sys-fs-bpf.mount
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Mount BPF Filesystem for Cilium eBPF
+        DefaultDependencies=no
+        Before=local-fs.target
+        [Mount]
+        What=bpffs
+        Where=/sys/fs/bpf
+        Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime
+        [Install]
+        WantedBy=local-fs.target
+
+    - name: crio.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CRI-O Container Runtime
+        Documentation=https://github.com/cri-o/cri-o
+        Requires=var-lib.mount
+        After=network.target local-fs.target var-lib.mount
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/crio
+        ExecReload=/bin/kill -HUP $MAINPID
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io
+        Requires=crio.service sys-fs-bpf.mount
+        After=crio.service sys-fs-bpf.mount
+        [Service]
+        ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubelet.conf --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - {{ SSH_PUBLIC_KEY }}
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}
+      groups:
+        - sudo
+      shell: /bin/bash
+      no_create_home: false
+  groups: []
+
+kernel_arguments:
+  should_exist: []
+  should_not_exist: []
+
+boot_device:
+  layout: x86_64
+  luks:
+    device: /dev/disk/by-id/REPLACE_ME
+    tpm2: true
+    threshold: 1
+    discard: false
+
+grub:
+  users:
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}

--- a/installation/k8s/coreos-lab/k8s3.bu
+++ b/installation/k8s/coreos-lab/k8s3.bu
@@ -1,3 +1,4 @@
+# boot device: /dev/disk/by-id/BOOT_DISK_REPLACE_ME
 variant: fcos
 version: 1.7.0
 
@@ -153,11 +154,6 @@ kernel_arguments:
 
 boot_device:
   layout: x86_64
-  luks:
-    device: /dev/disk/by-id/REPLACE_ME
-    tpm2: true
-    threshold: 1
-    discard: false
 
 grub:
   users:

--- a/installation/k8s/coreos-pis/.secrets.env.example
+++ b/installation/k8s/coreos-pis/.secrets.env.example
@@ -1,0 +1,2 @@
+SSH_PUBLIC_KEY='ssh-rsa AAAA...'
+PASSWORD_HASH='$y$j9T$...'

--- a/installation/k8s/coreos-pis/k8s1.bu
+++ b/installation/k8s/coreos-pis/k8s1.bu
@@ -1,3 +1,4 @@
+# boot device: /dev/disk/by-id/BOOT_DISK_REPLACE_ME
 variant: fcos
 version: 1.7.0
 
@@ -148,11 +149,6 @@ kernel_arguments:
 
 boot_device:
   layout: aarch64
-  luks:
-    device: /dev/disk/by-id/REPLACE_ME
-    tpm2: true
-    threshold: 1
-    discard: false
 
 grub:
   users:

--- a/installation/k8s/coreos-pis/k8s1.bu
+++ b/installation/k8s/coreos-pis/k8s1.bu
@@ -18,12 +18,7 @@ storage:
       partitions:
         - number: 1
           label: VARLIB
-          size_mib: 153600
-          start_mib: 0
-          wipe_partition_entry: true
-        - number: 2
-          label: CEPH
-          size_mib: 0
+          size_mib: 40960
           start_mib: 0
           wipe_partition_entry: true
   filesystems:

--- a/installation/k8s/coreos-pis/k8s1.bu
+++ b/installation/k8s/coreos-pis/k8s1.bu
@@ -1,0 +1,165 @@
+variant: fcos
+version: 1.7.0
+
+ignition:
+  config:
+    merge: []
+  timeouts:
+    http_response_headers: 10
+    http_total: 0
+  security:
+    tls:
+      certificate_authorities: []
+
+storage:
+  disks:
+    - device: /dev/disk/by-id/DATA_DISK_REPLACE_ME
+      wipe_table: true
+      partitions:
+        - number: 1
+          label: VARLIB
+          size_mib: 153600
+          start_mib: 0
+          wipe_partition_entry: true
+        - number: 2
+          label: CEPH
+          size_mib: 0
+          start_mib: 0
+          wipe_partition_entry: true
+  filesystems:
+    - device: /dev/disk/by-partlabel/VARLIB
+      format: ext4
+      label: VARLIB
+      path: /var/lib
+      options:
+        - -T
+        - small
+      wipe_filesystem: true
+      with_mount_unit: true
+  files:
+    - path: /etc/modules-load.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          overlay
+          br_netfilter
+    - path: /etc/sysctl.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+    - path: /etc/kubernetes/kubelet.yaml
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          resolvConf: /run/systemd/resolve/resolv.conf
+          rotateCertificates: true
+  directories: []
+  links: []
+
+systemd:
+  units:
+    - name: restorecon-var-lib.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Relabel /var/lib for SELinux
+        Requires=var-lib.mount
+        After=var-lib.mount
+        Before=crio.service kubelet.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/restorecon -R /var/lib
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: sys-fs-bpf.mount
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Mount BPF Filesystem for Cilium eBPF
+        DefaultDependencies=no
+        Before=local-fs.target
+        [Mount]
+        What=bpffs
+        Where=/sys/fs/bpf
+        Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime
+        [Install]
+        WantedBy=local-fs.target
+
+    - name: crio.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CRI-O Container Runtime
+        Documentation=https://github.com/cri-o/cri-o
+        Requires=var-lib.mount
+        After=network.target local-fs.target var-lib.mount
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/crio
+        ExecReload=/bin/kill -HUP $MAINPID
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io
+        Requires=crio.service sys-fs-bpf.mount
+        After=crio.service sys-fs-bpf.mount
+        [Service]
+        ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubelet.conf --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - {{ SSH_PUBLIC_KEY }}
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}
+      groups:
+        - sudo
+      shell: /bin/bash
+      no_create_home: false
+  groups: []
+
+kernel_arguments:
+  should_exist: []
+  should_not_exist: []
+
+boot_device:
+  layout: aarch64
+  luks:
+    device: /dev/disk/by-id/REPLACE_ME
+    tpm2: true
+    threshold: 1
+    discard: false
+
+grub:
+  users:
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}

--- a/installation/k8s/coreos-pis/k8s2.bu
+++ b/installation/k8s/coreos-pis/k8s2.bu
@@ -1,3 +1,4 @@
+# boot device: /dev/disk/by-id/BOOT_DISK_REPLACE_ME
 variant: fcos
 version: 1.7.0
 
@@ -148,11 +149,6 @@ kernel_arguments:
 
 boot_device:
   layout: aarch64
-  luks:
-    device: /dev/disk/by-id/REPLACE_ME
-    tpm2: true
-    threshold: 1
-    discard: false
 
 grub:
   users:

--- a/installation/k8s/coreos-pis/k8s2.bu
+++ b/installation/k8s/coreos-pis/k8s2.bu
@@ -18,12 +18,7 @@ storage:
       partitions:
         - number: 1
           label: VARLIB
-          size_mib: 153600
-          start_mib: 0
-          wipe_partition_entry: true
-        - number: 2
-          label: CEPH
-          size_mib: 0
+          size_mib: 40960
           start_mib: 0
           wipe_partition_entry: true
   filesystems:

--- a/installation/k8s/coreos-pis/k8s2.bu
+++ b/installation/k8s/coreos-pis/k8s2.bu
@@ -1,0 +1,165 @@
+variant: fcos
+version: 1.7.0
+
+ignition:
+  config:
+    merge: []
+  timeouts:
+    http_response_headers: 10
+    http_total: 0
+  security:
+    tls:
+      certificate_authorities: []
+
+storage:
+  disks:
+    - device: /dev/disk/by-id/DATA_DISK_REPLACE_ME
+      wipe_table: true
+      partitions:
+        - number: 1
+          label: VARLIB
+          size_mib: 153600
+          start_mib: 0
+          wipe_partition_entry: true
+        - number: 2
+          label: CEPH
+          size_mib: 0
+          start_mib: 0
+          wipe_partition_entry: true
+  filesystems:
+    - device: /dev/disk/by-partlabel/VARLIB
+      format: ext4
+      label: VARLIB
+      path: /var/lib
+      options:
+        - -T
+        - small
+      wipe_filesystem: true
+      with_mount_unit: true
+  files:
+    - path: /etc/modules-load.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          overlay
+          br_netfilter
+    - path: /etc/sysctl.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+    - path: /etc/kubernetes/kubelet.yaml
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          resolvConf: /run/systemd/resolve/resolv.conf
+          rotateCertificates: true
+  directories: []
+  links: []
+
+systemd:
+  units:
+    - name: restorecon-var-lib.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Relabel /var/lib for SELinux
+        Requires=var-lib.mount
+        After=var-lib.mount
+        Before=crio.service kubelet.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/restorecon -R /var/lib
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: sys-fs-bpf.mount
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Mount BPF Filesystem for Cilium eBPF
+        DefaultDependencies=no
+        Before=local-fs.target
+        [Mount]
+        What=bpffs
+        Where=/sys/fs/bpf
+        Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime
+        [Install]
+        WantedBy=local-fs.target
+
+    - name: crio.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CRI-O Container Runtime
+        Documentation=https://github.com/cri-o/cri-o
+        Requires=var-lib.mount
+        After=network.target local-fs.target var-lib.mount
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/crio
+        ExecReload=/bin/kill -HUP $MAINPID
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io
+        Requires=crio.service sys-fs-bpf.mount
+        After=crio.service sys-fs-bpf.mount
+        [Service]
+        ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubelet.conf --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - {{ SSH_PUBLIC_KEY }}
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}
+      groups:
+        - sudo
+      shell: /bin/bash
+      no_create_home: false
+  groups: []
+
+kernel_arguments:
+  should_exist: []
+  should_not_exist: []
+
+boot_device:
+  layout: aarch64
+  luks:
+    device: /dev/disk/by-id/REPLACE_ME
+    tpm2: true
+    threshold: 1
+    discard: false
+
+grub:
+  users:
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}

--- a/installation/k8s/coreos-pis/k8s3.bu
+++ b/installation/k8s/coreos-pis/k8s3.bu
@@ -1,3 +1,4 @@
+# boot device: /dev/disk/by-id/BOOT_DISK_REPLACE_ME
 variant: fcos
 version: 1.7.0
 
@@ -148,11 +149,6 @@ kernel_arguments:
 
 boot_device:
   layout: aarch64
-  luks:
-    device: /dev/disk/by-id/REPLACE_ME
-    tpm2: true
-    threshold: 1
-    discard: false
 
 grub:
   users:

--- a/installation/k8s/coreos-pis/k8s3.bu
+++ b/installation/k8s/coreos-pis/k8s3.bu
@@ -18,12 +18,7 @@ storage:
       partitions:
         - number: 1
           label: VARLIB
-          size_mib: 153600
-          start_mib: 0
-          wipe_partition_entry: true
-        - number: 2
-          label: CEPH
-          size_mib: 0
+          size_mib: 40960
           start_mib: 0
           wipe_partition_entry: true
   filesystems:

--- a/installation/k8s/coreos-pis/k8s3.bu
+++ b/installation/k8s/coreos-pis/k8s3.bu
@@ -1,0 +1,165 @@
+variant: fcos
+version: 1.7.0
+
+ignition:
+  config:
+    merge: []
+  timeouts:
+    http_response_headers: 10
+    http_total: 0
+  security:
+    tls:
+      certificate_authorities: []
+
+storage:
+  disks:
+    - device: /dev/disk/by-id/DATA_DISK_REPLACE_ME
+      wipe_table: true
+      partitions:
+        - number: 1
+          label: VARLIB
+          size_mib: 153600
+          start_mib: 0
+          wipe_partition_entry: true
+        - number: 2
+          label: CEPH
+          size_mib: 0
+          start_mib: 0
+          wipe_partition_entry: true
+  filesystems:
+    - device: /dev/disk/by-partlabel/VARLIB
+      format: ext4
+      label: VARLIB
+      path: /var/lib
+      options:
+        - -T
+        - small
+      wipe_filesystem: true
+      with_mount_unit: true
+  files:
+    - path: /etc/modules-load.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          overlay
+          br_netfilter
+    - path: /etc/sysctl.d/k8s.conf
+      mode: 0644
+      contents:
+        inline: |
+          net.bridge.bridge-nf-call-iptables = 1
+          net.bridge.bridge-nf-call-ip6tables = 1
+          net.ipv4.ip_forward = 1
+    - path: /etc/kubernetes/kubelet.yaml
+      mode: 0644
+      contents:
+        inline: |
+          kind: KubeletConfiguration
+          apiVersion: kubelet.config.k8s.io/v1beta1
+          authentication:
+            anonymous:
+              enabled: false
+            webhook:
+              enabled: true
+          authorization:
+            mode: Webhook
+          cgroupDriver: systemd
+          clusterDomain: cluster.local
+          resolvConf: /run/systemd/resolve/resolv.conf
+          rotateCertificates: true
+  directories: []
+  links: []
+
+systemd:
+  units:
+    - name: restorecon-var-lib.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Relabel /var/lib for SELinux
+        Requires=var-lib.mount
+        After=var-lib.mount
+        Before=crio.service kubelet.service
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/restorecon -R /var/lib
+        RemainAfterExit=yes
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: sys-fs-bpf.mount
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Mount BPF Filesystem for Cilium eBPF
+        DefaultDependencies=no
+        Before=local-fs.target
+        [Mount]
+        What=bpffs
+        Where=/sys/fs/bpf
+        Type=bpf
+        Options=rw,nosuid,nodev,noexec,relatime
+        [Install]
+        WantedBy=local-fs.target
+
+    - name: crio.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=CRI-O Container Runtime
+        Documentation=https://github.com/cri-o/cri-o
+        Requires=var-lib.mount
+        After=network.target local-fs.target var-lib.mount
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/crio
+        ExecReload=/bin/kill -HUP $MAINPID
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=kubelet: The Kubernetes Node Agent
+        Documentation=https://kubernetes.io
+        Requires=crio.service sys-fs-bpf.mount
+        After=crio.service sys-fs-bpf.mount
+        [Service]
+        ExecStart=/usr/bin/kubelet --config=/etc/kubernetes/kubelet.yaml --kubeconfig=/etc/kubernetes/kubelet.conf --container-runtime-endpoint=unix:///var/run/crio/crio.sock
+        Restart=always
+        RestartSec=10
+        [Install]
+        WantedBy=multi-user.target
+
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+        - {{ SSH_PUBLIC_KEY }}
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}
+      groups:
+        - sudo
+      shell: /bin/bash
+      no_create_home: false
+  groups: []
+
+kernel_arguments:
+  should_exist: []
+  should_not_exist: []
+
+boot_device:
+  layout: aarch64
+  luks:
+    device: /dev/disk/by-id/REPLACE_ME
+    tpm2: true
+    threshold: 1
+    discard: false
+
+grub:
+  users:
+    - name: homelab
+      password_hash: {{ PASSWORD_HASH }}

--- a/installation/k8s/create-ignition.sh
+++ b/installation/k8s/create-ignition.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+tmp=""
+trap '[[ -n "$tmp" ]] && rm -f "$tmp"' EXIT
+
+case "${1:-}" in
+  lab) dir=coreos-lab ;;
+  pis) dir=coreos-pis ;;
+  "")
+    echo "usage: $0 {lab|pis}" >&2
+    exit 1
+    ;;
+  *)
+    echo "error: unknown target '$1' (expected lab or pis)" >&2
+    exit 1
+    ;;
+esac
+
+SECRETS_FILE="$SCRIPT_DIR/$dir/.secrets.env"
+if [[ ! -f "$SECRETS_FILE" ]]; then
+  echo "error: missing $SECRETS_FILE (copy $dir/.secrets.env.example and fill in values)" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$SECRETS_FILE"
+
+if [[ -z "${SSH_PUBLIC_KEY:-}" || -z "${PASSWORD_HASH:-}" ]]; then
+  echo "error: SSH_PUBLIC_KEY and PASSWORD_HASH must be set in $SECRETS_FILE" >&2
+  exit 1
+fi
+
+if ! command -v butane >/dev/null 2>&1; then
+  echo "error: butane not found in PATH" >&2
+  exit 1
+fi
+
+for bu in "$dir"/*.bu; do
+  [[ -f "$bu" ]] || continue
+  out="${bu%.bu}.ign"
+  tmp="$(mktemp)"
+  sed "s|{{ SSH_PUBLIC_KEY }}|$SSH_PUBLIC_KEY|g; s|{{ PASSWORD_HASH }}|$PASSWORD_HASH|g" "$bu" \
+    | butane --pretty --strict > "$tmp"
+  mv "$tmp" "$out"
+  echo "rendered $out"
+done


### PR DESCRIPTION
# Description of changes made
- Incepts .bu template for k8s on CoreOS
- Incepts `create-ignition.sh` for generating ignition from butane configs
- Differentiates between `coreos-lab` and `coreos-pis` for 2 different k8s cluster builds
Ref: https://coreos.github.io/butane/config-fcos-v1_7/
